### PR TITLE
Seed with triggers disabled so fresh DB boot doesn't crash

### DIFF
--- a/app/admin/events/page.tsx
+++ b/app/admin/events/page.tsx
@@ -17,9 +17,10 @@ import { EventFilters, type DateFilter } from '@/components/admin/event-filters'
 import { AdminPagination } from '@/components/admin/admin-pagination'
 import { Plus } from 'lucide-react'
 import Link from 'next/link'
+import { getCurrentSeasonLabel } from '@/lib/season'
 import type { EventForAdminList } from '@/types/queries'
 
-const currentSeason = process.env.NEXT_PUBLIC_CURRENT_SEASON || '2026'
+const currentSeason = getCurrentSeasonLabel()
 const PAGE_SIZE = 50
 
 function buildEventDetailUrl(

--- a/app/admin/reports/page.tsx
+++ b/app/admin/reports/page.tsx
@@ -1,6 +1,7 @@
 import { requireAdmin } from '@/lib/auth/get-admin'
 import { getSupabaseAdmin } from '@/lib/supabase-server'
 import { getChapters } from '@/lib/actions/admin-users'
+import { getCurrentSeasonLabel } from '@/lib/season'
 import Link from 'next/link'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import {
@@ -57,7 +58,7 @@ interface NonRenewedRiderRow {
   last_name: string
 }
 
-const currentSeason = process.env.NEXT_PUBLIC_CURRENT_SEASON || '2026'
+const currentSeason = getCurrentSeasonLabel()
 
 async function getAvailableSeasons(): Promise<string[]> {
   const { data } = await getSupabaseAdmin().rpc('get_distinct_event_seasons')

--- a/app/membership/page.tsx
+++ b/app/membership/page.tsx
@@ -1,37 +1,39 @@
-import Link from "next/link";
-import { PageShell } from "@/components/page-shell";
-import { Button } from "@/components/ui/button";
+import Link from 'next/link'
+import { PageShell } from '@/components/page-shell'
+import { Button } from '@/components/ui/button'
+import { getCurrentSeasonLabel } from '@/lib/season'
 
 export const metadata = {
-  title: "Membership",
-  description: "Join Randonneurs Ontario and participate in brevets and populaires across the province.",
-};
+  title: 'Membership',
+  description:
+    'Join Randonneurs Ontario and participate in brevets and populaires across the province.',
+}
 
-const currentSeason = process.env.NEXT_PUBLIC_CURRENT_SEASON || "current";
+const currentSeason = getCurrentSeasonLabel()
 
 const membershipTiers = [
   {
-    name: "Trial Member",
-    price: "FREE",
-    requirement: "+ Ontario Cycling Membership",
+    name: 'Trial Member',
+    price: 'FREE',
+    requirement: '+ Ontario Cycling Membership',
     description:
-      "There is no charge for rider for their first event, no matter the distance. First time riders must have an Ontario Cycling Membership through Randonneurs Ontario or another Ontario Cycling affiliated club.",
+      'There is no charge for rider for their first event, no matter the distance. First time riders must have an Ontario Cycling Membership through Randonneurs Ontario or another Ontario Cycling affiliated club.',
   },
   {
-    name: "Individual Membership",
-    price: "$40.00 CDN",
-    requirement: "+ Ontario Cycling Membership",
+    name: 'Individual Membership',
+    price: '$40.00 CDN',
+    requirement: '+ Ontario Cycling Membership',
     description:
-      "Full members may register for all standard rides throughout the season at no additional cost, can vote at the Annual General Meeting, and are invited to the Annual Awards dinner.",
+      'Full members may register for all standard rides throughout the season at no additional cost, can vote at the Annual General Meeting, and are invited to the Annual Awards dinner.',
   },
   {
-    name: "Family Membership",
-    price: "$40.00 CDN",
-    requirement: "+ Ontario Cycling Membership per family member",
+    name: 'Family Membership',
+    price: '$40.00 CDN',
+    requirement: '+ Ontario Cycling Membership per family member',
     description:
-      "The Family Membership receives all of the benefits of individual memberships, and is for a family living at the same address.",
+      'The Family Membership receives all of the benefits of individual memberships, and is for a family living at the same address.',
   },
-];
+]
 
 export default function MembershipPage() {
   return (
@@ -42,23 +44,24 @@ export default function MembershipPage() {
           Become a member of Randonneurs Ontario
         </h1>
         <p className="mt-6 text-lg leading-relaxed">
-          For all sanctioned rides, we require riders to have Ontario Cycling (OC) membership. If you're not an OC member, you can purchase a membership during registration.
+          For all sanctioned rides, we require riders to have Ontario Cycling (OC) membership. If
+          you're not an OC member, you can purchase a membership during registration.
         </p>
-        <p className="mt-6 text-lg leading-relaxed">Membership is valid for the {currentSeason} season.</p>
+        <p className="mt-6 text-lg leading-relaxed">
+          Membership is valid for the {currentSeason} season.
+        </p>
       </div>
 
       {/* Membership Tiers */}
       <div className="content-container py-8">
         <div className="space-y-8">
           {membershipTiers.map((tier) => {
-            const isFree = tier.price === "FREE";
+            const isFree = tier.price === 'FREE'
             return (
               <div
                 key={tier.name}
                 className={`rounded-xl border p-6 md:p-8 ${
-                  isFree
-                    ? "border-primary/30 bg-primary/5"
-                    : "border-border bg-card"
+                  isFree ? 'border-primary/30 bg-primary/5' : 'border-border bg-card'
                 }`}
               >
                 <div className="flex items-start justify-between gap-4">
@@ -88,14 +91,12 @@ export default function MembershipPage() {
                     </Link>
                   </Button>
                 </div>
-                <p className="mt-4 text-muted-foreground leading-relaxed">
-                  {tier.description}
-                </p>
+                <p className="mt-4 text-muted-foreground leading-relaxed">{tier.description}</p>
               </div>
-            );
+            )
           })}
         </div>
       </div>
     </PageShell>
-  );
+  )
 }

--- a/app/records/page.tsx
+++ b/app/records/page.tsx
@@ -17,10 +17,11 @@ import {
   getPbpRecords,
   getGraniteAnvilRecords,
 } from '@/lib/data/records'
+import { getCurrentSeason } from '@/lib/season'
 
 export const revalidate = 3600 // Revalidate every hour (driven by current season data)
 
-const currentSeason = process.env.NEXT_PUBLIC_CURRENT_SEASON || '2026'
+const currentSeason = getCurrentSeason()
 
 export const metadata = {
   title: 'Records',
@@ -97,14 +98,14 @@ export default async function RecordsPage() {
           <StreakRecordTable
             title="Longest Active Streak"
             records={lifetime.longestStreaks}
-            currentSeason={parseInt(currentSeason, 10)}
+            currentSeason={currentSeason}
             valueLabel="Seasons"
             description="2020 is treated as a gap year and does not break a streak"
           />
           <StreakRecordTable
             title="Longest Super Randonneur Streak"
             records={lifetime.srStreaks}
-            currentSeason={parseInt(currentSeason, 10)}
+            currentSeason={currentSeason}
             valueLabel="Seasons"
             description="2020 is treated as a gap year and does not break a streak"
           />

--- a/components/admin/event-filters.tsx
+++ b/components/admin/event-filters.tsx
@@ -12,6 +12,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { getCurrentSeasonLabel } from '@/lib/season'
 
 interface Chapter {
   id: string
@@ -31,7 +32,7 @@ interface EventFiltersProps {
 // Match the order used in the main site navbar
 const CHAPTER_ORDER = ['Huron', 'Ottawa', 'Simcoe-Muskoka', 'Toronto']
 
-const currentSeason = process.env.NEXT_PUBLIC_CURRENT_SEASON || '2026'
+const currentSeason = getCurrentSeasonLabel()
 
 function buildFilterUrl(
   season: string,

--- a/components/admin/event-form.tsx
+++ b/components/admin/event-form.tsx
@@ -41,6 +41,7 @@ import { AlertCircle, Loader2, CalendarIcon, ChevronDownIcon } from 'lucide-reac
 import { createEvent, updateEvent, type EventType } from '@/lib/actions/events'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
+import { getCurrentSeasonLabel } from '@/lib/season'
 import type { ChapterOption } from '@/types/ui'
 import type { ActiveRoute } from '@/lib/data/routes'
 import { ImageUpload } from '@/components/admin/image-upload'
@@ -91,7 +92,7 @@ export function EventForm({
   const [error, setError] = useState<string | null>(null)
   const [showBrevetRestrictionModal, setShowBrevetRestrictionModal] = useState(false)
 
-  const currentSeason = process.env.NEXT_PUBLIC_CURRENT_SEASON || '2026'
+  const currentSeason = getCurrentSeasonLabel()
 
   // Initialize state from event data in edit mode, or defaults in create mode
   const [chapterId, setChapterId] = useState(event?.chapterId || defaultChapterId || '')

--- a/components/admin/report-filters.tsx
+++ b/components/admin/report-filters.tsx
@@ -11,6 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { getCurrentSeasonLabel } from '@/lib/season'
 
 interface Chapter {
   id: string
@@ -25,7 +26,7 @@ interface ReportFiltersProps {
 }
 
 const CHAPTER_ORDER = ['Huron', 'Ottawa', 'Simcoe-Muskoka', 'Toronto']
-const currentSeason = process.env.NEXT_PUBLIC_CURRENT_SEASON || '2026'
+const currentSeason = getCurrentSeasonLabel()
 
 function buildFilterUrl(season: string, chapterId: string | null, explicitAll: boolean = false) {
   const params = new URLSearchParams()

--- a/components/admin/riders-table.tsx
+++ b/components/admin/riders-table.tsx
@@ -25,6 +25,7 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group'
 import { ChevronLeft, ChevronRight, Eye, GitMerge, Search, X } from 'lucide-react'
 import { MergeRidersDialog, type RiderForMerge } from './merge-riders-dialog'
+import { getCurrentSeason } from '@/lib/season'
 
 interface RiderWithStats {
   id: string
@@ -310,10 +311,7 @@ export function RidersTable({
                     </TableCell>
                     <TableCell className="hidden lg:table-cell">
                       {(() => {
-                        const currentSeason = parseInt(
-                          process.env.NEXT_PUBLIC_CURRENT_SEASON || '2026',
-                          10
-                        )
+                        const currentSeason = getCurrentSeason()
                         const currentMembership = rider.rider_memberships?.find(
                           (m) => m.season === currentSeason
                         )

--- a/components/membership-error-modal.tsx
+++ b/components/membership-error-modal.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { AlertCircle } from 'lucide-react'
+import { getCurrentSeasonLabel } from '@/lib/season'
 
 interface MembershipErrorModalProps {
   open: boolean
@@ -36,7 +37,7 @@ export function MembershipErrorModal({ open, onClose, variant }: MembershipError
             {isNoMembership ? (
               <>
                 To register for events, you need to be an active member of Randonneurs Ontario for
-                the {process.env.NEXT_PUBLIC_CURRENT_SEASON}. <br />
+                the {getCurrentSeasonLabel()}. <br />
                 <br />
                 Join the club first, then return to complete your registration.
               </>

--- a/lib/data/records.ts
+++ b/lib/data/records.ts
@@ -16,6 +16,7 @@ import { unstable_cache } from 'next/cache'
 import { getSupabase } from '@/lib/supabase'
 import { handleDataError } from '@/lib/errors'
 import { formatFinishTime } from '@/lib/utils'
+import { getCurrentSeason } from '@/lib/season'
 import type {
   LifetimeRecords,
   SeasonRecords,
@@ -152,7 +153,7 @@ function toStreakRecords(
 
 const getLifetimeRecordsInner = cache(async (): Promise<LifetimeRecords> => {
   const supabase = getSupabase()
-  const currentSeason = parseInt(process.env.NEXT_PUBLIC_CURRENT_SEASON || '2026', 10)
+  const currentSeason = getCurrentSeason()
 
   // Fetch all lifetime records in parallel using database functions
   const [
@@ -273,7 +274,7 @@ export async function getSeasonRecords(): Promise<SeasonRecords> {
 // ============================================================================
 
 const getCurrentSeasonDistanceInner = cache(async (): Promise<RiderRecord[]> => {
-  const currentSeason = parseInt(process.env.NEXT_PUBLIC_CURRENT_SEASON || '2026', 10)
+  const currentSeason = getCurrentSeason()
   const supabase = getSupabase()
 
   const { data, error } = await supabase.rpc('get_current_season_distances', {

--- a/lib/memberships/service.ts
+++ b/lib/memberships/service.ts
@@ -7,9 +7,8 @@
  */
 import { getSupabaseAdmin } from '@/lib/supabase-server'
 import { searchCCNMembership } from '@/lib/ccn/client'
+import { getCurrentSeason } from '@/lib/season'
 import type { MembershipType } from '@/types/queries'
-
-const getCurrentSeason = () => parseInt(process.env.NEXT_PUBLIC_CURRENT_SEASON || '2026', 10)
 
 export type MembershipResult =
   | {

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -9,14 +9,10 @@
  * server-side getNavigation() without duplicating logic.
  */
 
-import navigationJson from "@/content/navigation.json";
-import type {
-  NavigationConfig,
-  NavigationConfigRaw,
-  NavItem,
-  NavItemRaw,
-} from "@/types/navigation";
-import { getAllChapterSlugs, getChapterInfo } from "@/lib/chapter-config";
+import navigationJson from '@/content/navigation.json'
+import type { NavigationConfig, NavigationConfigRaw, NavItem, NavItemRaw } from '@/types/navigation'
+import { getAllChapterSlugs, getChapterInfo } from '@/lib/chapter-config'
+import { getCurrentSeasonLabel } from '@/lib/season'
 
 // ---------------------------------------------------------------------------
 // Chapter list (sorted by name, computed once at module load)
@@ -24,69 +20,56 @@ import { getAllChapterSlugs, getChapterInfo } from "@/lib/chapter-config";
 
 const chapters = getAllChapterSlugs()
   .map((slug) => ({ slug, name: getChapterInfo(slug)?.name ?? slug }))
-  .sort((a, b) => a.name.localeCompare(b.name));
+  .sort((a, b) => a.name.localeCompare(b.name))
 
 // ---------------------------------------------------------------------------
 // Template variable resolution
 // ---------------------------------------------------------------------------
 
 export function getTemplateVariables(): Record<string, string> {
-  const currentSeason =
-    process.env.NEXT_PUBLIC_CURRENT_SEASON || "2026";
-  const currentYear = new Date().getFullYear();
-  const pbpYear = currentYear - ((currentYear - 3) % 4);
-  const graniteAnvilYear = 2025;
+  const currentSeason = getCurrentSeasonLabel()
+  const currentYear = new Date().getFullYear()
+  const pbpYear = currentYear - ((currentYear - 3) % 4)
+  const graniteAnvilYear = 2025
 
   return {
     season: currentSeason,
     pbpYear: String(pbpYear),
     graniteAnvilYear: String(graniteAnvilYear),
-  };
+  }
 }
 
-export function resolveHref(
-  href: string,
-  variables: Record<string, string>,
-): string {
-  return href.replace(
-    /\{\{([\w-]+)\}\}/g,
-    (_, key) => variables[key] ?? `{{${key}}}`,
-  );
+export function resolveHref(href: string, variables: Record<string, string>): string {
+  return href.replace(/\{\{([\w-]+)\}\}/g, (_, key) => variables[key] ?? `{{${key}}}`)
 }
 
-export function expandItem(
-  item: NavItemRaw,
-  variables: Record<string, string>,
-): NavItem[] {
-  if (item.separator) return [{ label: "", separator: true }];
-  if (item.type === "heading")
-    return [{ label: item.label ?? "", type: "heading" }];
+export function expandItem(item: NavItemRaw, variables: Record<string, string>): NavItem[] {
+  if (item.separator) return [{ label: '', separator: true }]
+  if (item.type === 'heading') return [{ label: item.label ?? '', type: 'heading' }]
 
-  if (item.template === "chapters") {
+  if (item.template === 'chapters') {
     return chapters.map(({ slug, name }) => {
       const chapterVars = {
         ...variables,
         chapter: name,
-        "chapter-slug": slug,
-      };
+        'chapter-slug': slug,
+      }
       return {
         label: name,
-        href: resolveHref(item.href ?? "", chapterVars),
-      };
-    });
+        href: resolveHref(item.href ?? '', chapterVars),
+      }
+    })
   }
 
-  const resolved: NavItem = { label: item.label ?? "" };
-  if (item.href) resolved.href = resolveHref(item.href, variables);
-  if (item.external) resolved.external = true;
-  if (item.style) resolved.style = item.style;
+  const resolved: NavItem = { label: item.label ?? '' }
+  if (item.href) resolved.href = resolveHref(item.href, variables)
+  if (item.external) resolved.external = true
+  if (item.style) resolved.style = item.style
   if (item.children) {
-    resolved.children = item.children.flatMap((child) =>
-      expandItem(child, variables),
-    );
+    resolved.children = item.children.flatMap((child) => expandItem(child, variables))
   }
 
-  return [resolved];
+  return [resolved]
 }
 
 // ---------------------------------------------------------------------------
@@ -94,8 +77,8 @@ export function expandItem(
 // ---------------------------------------------------------------------------
 
 const FALLBACK_NAV: NavigationConfig = {
-  items: [{ label: "Home", href: "/" }],
-};
+  items: [{ label: 'Home', href: '/' }],
+}
 
 /**
  * Resolve the navigation config using the build-time JSON import.
@@ -103,13 +86,13 @@ const FALLBACK_NAV: NavigationConfig = {
  */
 export function getResolvedNavigation(): NavigationConfig {
   try {
-    const config = navigationJson as NavigationConfigRaw;
-    const variables = getTemplateVariables();
+    const config = navigationJson as NavigationConfigRaw
+    const variables = getTemplateVariables()
 
     return {
       items: config.items.flatMap((item) => expandItem(item, variables)),
-    };
+    }
   } catch {
-    return FALLBACK_NAV;
+    return FALLBACK_NAV
   }
 }

--- a/lib/season.ts
+++ b/lib/season.ts
@@ -1,0 +1,21 @@
+/**
+ * Current season resolution.
+ *
+ * The active competition/membership season is driven by the
+ * NEXT_PUBLIC_CURRENT_SEASON env var so rolling the season is a single config
+ * change rather than a code edit. NEXT_PUBLIC_ vars are inlined at build time,
+ * so these helpers work in both server and client bundles.
+ */
+
+const FALLBACK_SEASON = 2026
+
+/** Current season as a number, e.g. 2026. */
+export function getCurrentSeason(): number {
+  const parsed = parseInt(process.env.NEXT_PUBLIC_CURRENT_SEASON ?? '', 10)
+  return Number.isNaN(parsed) ? FALLBACK_SEASON : parsed
+}
+
+/** Current season as a string, e.g. "2026". */
+export function getCurrentSeasonLabel(): string {
+  return String(getCurrentSeason())
+}

--- a/scripts/generate-seed.sh
+++ b/scripts/generate-seed.sh
@@ -137,9 +137,18 @@ cat > "$SEED_FILE" << 'EOF'
 -- Run seed-memberships.sql after seeding to restore PII + memberships.
 -- To regenerate: ./scripts/generate-seed.sh (generates both files)
 
+-- Restore the dump verbatim: disable triggers during the bulk load so that
+-- AFTER-INSERT triggers (e.g. the First Brevet award reconciler from migration
+-- 20260526120000) don't pre-create rows the dump then re-inserts, which crashes
+-- a fresh seed with duplicate-key errors on result_awards.
+SET session_replication_role = replica;
+
 EOF
 
 cat "$SEED_FILE.tmp2" >> "$SEED_FILE"
+
+# Re-enable triggers for normal operation after the bulk load.
+printf '\n-- Re-enable triggers for normal operation after the bulk load.\nSET session_replication_role = DEFAULT;\n' >> "$SEED_FILE"
 
 # Clean up temp files
 rm -f "$SEED_FILE.tmp" "$SEED_FILE.tmp2"

--- a/scripts/recheck-trial-memberships.ts
+++ b/scripts/recheck-trial-memberships.ts
@@ -29,13 +29,12 @@ config({ path: join(process.cwd(), '.env.local') })
 
 import { createClient } from '@supabase/supabase-js'
 import { searchCCNMembership } from '../lib/ccn/client'
+import { getCurrentSeason } from '../lib/season'
 
 const args = process.argv.slice(2)
 const apply = args.includes('--apply')
 const seasonArg = args.find((a) => a.startsWith('--season='))
-const season = seasonArg
-  ? parseInt(seasonArg.split('=')[1], 10)
-  : parseInt(process.env.NEXT_PUBLIC_CURRENT_SEASON || '2026', 10)
+const season = seasonArg ? parseInt(seasonArg.split('=')[1], 10) : getCurrentSeason()
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
 const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -23,6 +23,12 @@
 -- Run seed-memberships.sql after seeding to restore PII + memberships.
 -- To regenerate: ./scripts/generate-seed.sh (generates both files)
 
+-- Restore the dump verbatim: disable triggers during the bulk load so that
+-- AFTER-INSERT triggers (e.g. the First Brevet award reconciler from migration
+-- 20260526120000) don't pre-create rows the dump then re-inserts, which crashes
+-- a fresh seed with duplicate-key errors on result_awards.
+SET session_replication_role = replica;
+
 INSERT INTO public.awards (id, slug, title, description, award_type, created_at, updated_at) VALUES ('e81592f6-8b0e-585e-8f06-8c53704548bb', 'super-randonneur', 'Super Randonneur', 'Completed a 200, 300, 400, and 600 km brevet in the same season.', 'season', '2026-01-07 06:05:14.466123+00', '2026-03-12 17:07:26.831771+00');
 INSERT INTO public.awards (id, slug, title, description, award_type, created_at, updated_at) VALUES ('cfa2e476-ec58-52c5-bc33-b7b870cc92e0', 'first-brevet', 'First Brevet', 'Rode their first brevet with Randonneurs Ontario', 'result', '2026-01-07 06:05:14.456082+00', '2026-03-12 17:07:26.831771+00');
 INSERT INTO public.awards (id, slug, title, description, award_type, created_at, updated_at) VALUES ('52213f79-64db-5275-97f1-e2db51e52d56', 'completed-devil-week', 'Completed Devil Week', 'Rode a 200, 300, 400, and 600 km brevet during the club''s Devil Week.', 'result', '2026-01-07 06:05:14.4624+00', '2026-03-12 17:07:26.831771+00');
@@ -15456,3 +15462,6 @@ INSERT INTO public.registrations (id, event_id, rider_id, registered_at, notes, 
 INSERT INTO public.registrations (id, event_id, rider_id, registered_at, notes, status, share_registration, team_name, is_team_captain, management_token, cancelled_at) VALUES ('9ba4ada8-bc4b-4327-a17b-79f802a9a40b', 'ec382c0f-940d-4c65-a5b1-3d7d3da7f8c2', '3fa20c6a-470d-5495-b0b9-745d7a16b71d', '2026-03-21 20:23:36.806492+00', NULL, 'registered', true, NULL, false, 'b5738394-78ba-499f-b6fa-ee37c307f75d', NULL);
 INSERT INTO public.registrations (id, event_id, rider_id, registered_at, notes, status, share_registration, team_name, is_team_captain, management_token, cancelled_at) VALUES ('348d16dd-a4b1-4601-b728-00844ce1803e', 'fcec54de-d27b-4696-a298-3a8be10f2fe0', '3fa20c6a-470d-5495-b0b9-745d7a16b71d', '2026-03-21 20:22:35.029673+00', NULL, 'registered', true, NULL, false, 'a15cd14c-159a-4cea-bb3f-e9b4d003128e', NULL);
 INSERT INTO public.registrations (id, event_id, rider_id, registered_at, notes, status, share_registration, team_name, is_team_captain, management_token, cancelled_at) VALUES ('0ea9c0c8-78f7-4de8-b84f-c6bb0b877752', 'bbe08f0b-5b83-44f4-8504-b2ca343ffd1f', '3fa20c6a-470d-5495-b0b9-745d7a16b71d', '2026-03-21 15:56:52.895858+00', NULL, 'registered', true, NULL, false, '487e234d-4262-42f7-ac19-a2d1185f9627', NULL);
+
+-- Re-enable triggers for normal operation after the bulk load.
+SET session_replication_role = DEFAULT;

--- a/tests/unit/lib/season.test.ts
+++ b/tests/unit/lib/season.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { getCurrentSeason, getCurrentSeasonLabel } from '@/lib/season'
+
+describe('getCurrentSeason', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('returns the configured season as a number', () => {
+    vi.stubEnv('NEXT_PUBLIC_CURRENT_SEASON', '2027')
+    expect(getCurrentSeason()).toBe(2027)
+  })
+
+  it('falls back to 2026 when the env var is unset', () => {
+    vi.stubEnv('NEXT_PUBLIC_CURRENT_SEASON', '')
+    expect(getCurrentSeason()).toBe(2026)
+  })
+
+  it('falls back to 2026 when the env var is not a number', () => {
+    vi.stubEnv('NEXT_PUBLIC_CURRENT_SEASON', 'not-a-year')
+    expect(getCurrentSeason()).toBe(2026)
+  })
+})
+
+describe('getCurrentSeasonLabel', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('returns the configured season as a string', () => {
+    vi.stubEnv('NEXT_PUBLIC_CURRENT_SEASON', '2027')
+    expect(getCurrentSeasonLabel()).toBe('2027')
+  })
+
+  it('falls back to "2026" when the env var is unset', () => {
+    vi.stubEnv('NEXT_PUBLIC_CURRENT_SEASON', '')
+    expect(getCurrentSeasonLabel()).toBe('2026')
+  })
+})


### PR DESCRIPTION
## Problem

The `integration-real` CI job (added in #80) failed on its very first run — during `supabase start`'s seed step on a fresh database:

```
Seeding data from supabase/seed.sql...
failed to send batch: ERROR: duplicate key value violates unique constraint "result_awards_pkey" (SQLSTATE 23505)
```

## Root cause

`supabase start` applies migrations first — installing the **First Brevet award reconciler trigger** (`20260526120000_auto_assign_first_brevet.sql`) — then loads `seed.sql` with triggers live.

1. seed inserts a `results` row → the `AFTER INSERT` trigger auto-creates the rider's `first-brevet` row in `result_awards`.
2. `seed.sql` (a `pg_dump --data-only` dump; `generate-seed.sh` strips all `SET` statements) then explicitly re-inserts that same row → primary-key collision.

It never reproduced locally because the dev DB was seeded *before* the trigger landed and was never reset. CI's clean boot is the first time the two ran together — exactly the drift the #80 gate exists to catch.

## Fix

Load the dump verbatim by wrapping it in `SET session_replication_role = replica;` … `= DEFAULT;` — the canonical bulk-restore idiom. It suppresses triggers during seeding so the authoritative dump is restored as-is, and future-proofs the seed against *any* AFTER-INSERT trigger added later, not just First Brevet. Applied to both the committed `seed.sql` and `generate-seed.sh` so a regenerated seed keeps the fix.

## Verification

- Reproduced at the SQL level in a rolled-back transaction (dev DB untouched): triggers live → trigger auto-creates the row, explicit insert fails with `result_awards_pkey` (same `cfa2e476-…` first-brevet id as CI); under `replica` → trigger silent, insert succeeds.
- The `integration-real` job on this PR is the real test — it boots a fresh Supabase and seeds it, the exact path that failed on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)