### PR TITLE
Stack admin rider results rows into cards on mobile

### DIFF
--- a/app/admin/events/page.tsx
+++ b/app/admin/events/page.tsx
@@ -2,17 +2,7 @@ import { requireAdmin } from '@/lib/auth/get-admin'
 import { getSupabaseAdmin } from '@/lib/supabase-server'
 import { getChapters } from '@/lib/actions/admin-users'
 import { getEventRiderCounts } from '@/lib/data/event-rider-counts'
-import { parseLocalDate } from '@/lib/utils'
-import { ClickableTableRow } from '@/components/admin/clickable-table-row'
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table'
-import { Badge } from '@/components/ui/badge'
+import { EventsTable } from '@/components/admin/events-table'
 import { Button } from '@/components/ui/button'
 import { EventFilters, type DateFilter } from '@/components/admin/event-filters'
 import { AdminPagination } from '@/components/admin/admin-pagination'
@@ -164,21 +154,6 @@ export default async function AdminEventsPage({ searchParams }: AdminEventsPageP
     page
   )
 
-  const getStatusBadge = (status: string) => {
-    switch (status) {
-      case 'scheduled':
-        return <Badge variant="secondary">Scheduled</Badge>
-      case 'completed':
-        return <Badge>Completed</Badge>
-      case 'submitted':
-        return <Badge className="bg-green-600 hover:bg-green-600">Submitted</Badge>
-      case 'cancelled':
-        return <Badge variant="destructive">Cancelled</Badge>
-      default:
-        return <Badge variant="outline">{status}</Badge>
-    }
-  }
-
   return (
     <div className="space-y-6">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
@@ -204,59 +179,12 @@ export default async function AdminEventsPage({ searchParams }: AdminEventsPageP
         dateFilter={dateFilter}
       />
 
-      <div className="rounded-md border">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Event</TableHead>
-              <TableHead className="hidden md:table-cell">Chapter</TableHead>
-              <TableHead>Date</TableHead>
-              <TableHead className="hidden sm:table-cell">Distance</TableHead>
-              <TableHead className="hidden sm:table-cell">Riders</TableHead>
-              <TableHead>Status</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {events.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={6} className="text-center text-muted-foreground">
-                  No events found
-                </TableCell>
-              </TableRow>
-            ) : (
-              events.map((event) => (
-                <ClickableTableRow
-                  key={event.id}
-                  href={buildEventDetailUrl(event.id, season, chapterId, dateFilter)}
-                >
-                  <TableCell>
-                    <div>
-                      <span className="font-medium">{event.name}</span>
-                      <p className="text-sm text-muted-foreground capitalize">{event.event_type}</p>
-                    </div>
-                  </TableCell>
-                  <TableCell className="hidden md:table-cell">
-                    {event.chapters?.name || '—'}
-                  </TableCell>
-                  <TableCell>
-                    {parseLocalDate(event.event_date).toLocaleDateString('en-CA', {
-                      weekday: 'short',
-                      month: 'short',
-                      day: 'numeric',
-                      year: 'numeric',
-                    })}
-                  </TableCell>
-                  <TableCell className="hidden sm:table-cell">{event.distance_km} km</TableCell>
-                  <TableCell className="hidden sm:table-cell tabular-nums">
-                    {event.rider_count ?? 0}
-                  </TableCell>
-                  <TableCell>{getStatusBadge(event.status ?? 'scheduled')}</TableCell>
-                </ClickableTableRow>
-              ))
-            )}
-          </TableBody>
-        </Table>
-      </div>
+      <EventsTable
+        events={events}
+        buildEventDetailUrl={(eventId) =>
+          buildEventDetailUrl(eventId, season, chapterId, dateFilter)
+        }
+      />
 
       {totalCount > 0 && (
         <AdminPagination

--- a/components/admin/event-checkins-grid.tsx
+++ b/components/admin/event-checkins-grid.tsx
@@ -29,6 +29,7 @@ import {
   type AdminCheckinGridRider,
 } from '@/lib/actions/control-checkins'
 import type { CheckinFlags } from '@/lib/brevet-card'
+import { cn } from '@/lib/utils'
 import { formatControlTime } from '@/lib/brmTimes'
 import { toast } from 'sonner'
 import Link from 'next/link'
@@ -141,8 +142,8 @@ export function EventCheckinsGrid({
         </p>
       ) : (
         <div className="overflow-x-auto border rounded-md">
-          <Table>
-            <TableHeader>
+          <Table className="block sm:table">
+            <TableHeader className="hidden sm:table-header-group">
               <TableRow>
                 <TableHead className="min-w-[160px] sticky left-0 bg-background">Rider</TableHead>
                 {controls.map((control) => (
@@ -155,7 +156,7 @@ export function EventCheckinsGrid({
                 ))}
               </TableRow>
             </TableHeader>
-            <TableBody>
+            <TableBody className="block sm:table-row-group">
               {riders.map((rider) => (
                 <RiderRow
                   key={rider.registrationId}
@@ -211,8 +212,8 @@ const RiderRow = memo(function RiderRow({
   }, [rider.checkins])
 
   return (
-    <TableRow>
-      <TableCell className="font-medium sticky left-0 bg-background">
+    <TableRow className="block p-4 sm:table-row sm:p-0">
+      <TableCell className="sticky left-0 block bg-background p-0 pb-1 font-medium sm:table-cell sm:p-3 sm:pb-3">
         <div className="flex items-center gap-1.5">
           <span>{rider.riderName}</span>
           {rider.managementToken && (
@@ -235,16 +236,23 @@ const RiderRow = memo(function RiderRow({
         return (
           <TableCell
             key={control.id}
-            className={eventSubmitted ? '' : 'cursor-pointer hover:bg-muted/50'}
+            className={cn(
+              // One labelled line per control in the mobile card; regular cell from sm up
+              'flex items-baseline justify-between gap-3 p-0 py-1 sm:table-cell sm:p-3',
+              !eventSubmitted && 'cursor-pointer hover:bg-muted/50'
+            )}
             onClick={() => onOpenCell(rider, control, checkin)}
           >
+            <span className="text-xs text-muted-foreground sm:hidden">
+              {control.name} · {control.distanceKm} km
+            </span>
             {checkin ? (
               <div className="space-y-1">
                 <div className="tabular-nums">
                   {formatControlTime(new Date(checkin.checkedInAt))}
                 </div>
                 {activeFlags.length > 0 && (
-                  <div className="flex flex-wrap gap-1">
+                  <div className="flex flex-wrap justify-end gap-1 sm:justify-start">
                     {activeFlags.map(({ key, label, title }) => (
                       <Badge
                         key={key}

--- a/components/admin/event-controls-manager.tsx
+++ b/components/admin/event-controls-manager.tsx
@@ -29,6 +29,7 @@ import {
   type EventControlInput,
 } from '@/lib/actions/event-controls'
 import { DEFAULT_CONTROL_RADIUS_M } from '@/lib/brevet-card'
+import { cn } from '@/lib/utils'
 import { toast } from 'sonner'
 import { Download, Loader2, Plus, Save, Trash2 } from 'lucide-react'
 
@@ -50,6 +51,9 @@ interface EventControlsManagerProps {
   initialControls: AdminEventControl[]
   hasRwgpsRoute: boolean
 }
+
+// Mobile-only field label for the stacked card layout (< sm)
+const MOBILE_LABEL = 'w-20 shrink-0 text-xs font-medium text-muted-foreground sm:hidden'
 
 let rowKeyCounter = 0
 function nextRowKey(): string {
@@ -255,8 +259,8 @@ export function EventControlsManager({
         </p>
       ) : (
         <div className="overflow-x-auto border rounded-md">
-          <Table>
-            <TableHeader>
+          <Table className="block sm:table">
+            <TableHeader className="hidden sm:table-header-group">
               <TableRow>
                 <TableHead className="min-w-[180px]">Name</TableHead>
                 <TableHead className="w-24 text-right">Km</TableHead>
@@ -268,17 +272,22 @@ export function EventControlsManager({
                 <TableHead className="w-12" />
               </TableRow>
             </TableHeader>
-            <TableBody>
+            <TableBody className="block sm:table-row-group">
               {rows.map((row) => (
-                <TableRow key={row.key}>
-                  <TableCell>
+                <TableRow
+                  key={row.key}
+                  className="relative block space-y-2 p-4 sm:table-row sm:space-y-0 sm:p-0"
+                >
+                  <TableCell className="flex items-center gap-3 p-0 pr-12 sm:table-cell sm:p-3 sm:pr-3">
+                    <span className={MOBILE_LABEL}>Name</span>
                     <Input
                       value={row.name}
                       onChange={(e) => updateRow(row.key, 'name', e.target.value)}
                       placeholder="Control name"
                     />
                   </TableCell>
-                  <TableCell>
+                  <TableCell className="flex items-center gap-3 p-0 sm:table-cell sm:p-3">
+                    <span className={MOBILE_LABEL}>Km</span>
                     <Input
                       value={row.distanceKm}
                       onChange={(e) => updateRow(row.key, 'distanceKm', e.target.value)}
@@ -286,7 +295,8 @@ export function EventControlsManager({
                       className="text-right tabular-nums"
                     />
                   </TableCell>
-                  <TableCell>
+                  <TableCell className="flex items-center gap-3 p-0 sm:table-cell sm:p-3">
+                    <span className={MOBILE_LABEL}>Latitude</span>
                     <Input
                       value={row.lat}
                       onChange={(e) => updateRow(row.key, 'lat', e.target.value)}
@@ -295,7 +305,8 @@ export function EventControlsManager({
                       className="tabular-nums"
                     />
                   </TableCell>
-                  <TableCell>
+                  <TableCell className="flex items-center gap-3 p-0 sm:table-cell sm:p-3">
+                    <span className={MOBILE_LABEL}>Longitude</span>
                     <Input
                       value={row.lng}
                       onChange={(e) => updateRow(row.key, 'lng', e.target.value)}
@@ -304,7 +315,8 @@ export function EventControlsManager({
                       className="tabular-nums"
                     />
                   </TableCell>
-                  <TableCell>
+                  <TableCell className="flex items-center gap-3 p-0 sm:table-cell sm:p-3">
+                    <span className={MOBILE_LABEL}>Radius (m)</span>
                     <Input
                       value={row.radiusM}
                       onChange={(e) => updateRow(row.key, 'radiusM', e.target.value)}
@@ -312,17 +324,24 @@ export function EventControlsManager({
                       className="text-right tabular-nums"
                     />
                   </TableCell>
-                  <TableCell>
+                  <TableCell className="flex items-center gap-3 p-0 sm:table-cell sm:p-3">
+                    <span className={MOBILE_LABEL}>Notes</span>
                     <Input
                       value={row.notes}
                       onChange={(e) => updateRow(row.key, 'notes', e.target.value)}
                       placeholder="Optional"
                     />
                   </TableCell>
-                  <TableCell className="text-right tabular-nums text-muted-foreground">
+                  <TableCell
+                    className={cn(
+                      'items-center gap-3 p-0 text-muted-foreground tabular-nums sm:table-cell sm:p-3 sm:text-right',
+                      row.checkinCount > 0 ? 'flex' : 'hidden'
+                    )}
+                  >
+                    <span className={MOBILE_LABEL}>Check-ins</span>
                     {row.checkinCount}
                   </TableCell>
-                  <TableCell>
+                  <TableCell className="absolute top-2.5 right-2.5 block p-0 sm:static sm:table-cell sm:p-3">
                     <Button
                       variant="ghost"
                       size="icon"

--- a/components/admin/event-results-manager.tsx
+++ b/components/admin/event-results-manager.tsx
@@ -67,7 +67,7 @@ import {
   revalidateMembership,
   type ResultStatus,
 } from '@/lib/actions/results'
-import { formatFinishTime, buildParticipantMailtoUrl, buildRiderInfoText } from '@/lib/utils'
+import { cn, formatFinishTime, buildParticipantMailtoUrl, buildRiderInfoText } from '@/lib/utils'
 import { SubmitResultsButton } from './submit-results-button'
 import { AddRiderDialog } from './add-rider-dialog'
 import { toast } from 'sonner'
@@ -162,6 +162,9 @@ interface EventResultsManagerProps {
   results: Result[]
   firstTimeRiderIds: string[]
 }
+
+// Mobile-only field label for the stacked card layout (< sm)
+const MOBILE_LABEL = 'w-16 shrink-0 text-xs font-medium text-muted-foreground sm:hidden'
 
 const STATUS_OPTIONS: { value: ResultStatus; label: string }[] = [
   { value: 'pending', label: '—' },
@@ -289,6 +292,14 @@ function RiderRow({
   const isFleche = eventType === 'fleche'
 
   const riderName = `${participant.firstName} ${participant.lastName}`
+  const hasEvidence = !!(
+    result &&
+    (result.gpx_url ||
+      result.gpx_file_path ||
+      result.control_card_front_path ||
+      result.control_card_back_path)
+  )
+  const hasNotes = !!(participant.registrationNotes || result?.rider_notes)
 
   const flashSaved = useCallback(() => {
     setShowSaved(true)
@@ -423,8 +434,14 @@ function RiderRow({
   }
 
   return (
-    <TableRow className={isPending ? 'opacity-60' : undefined}>
-      <TableCell className="font-medium">
+    <TableRow
+      className={cn(
+        // Stacked card on mobile, regular table row from sm up
+        'relative block space-y-2 p-4 sm:table-row sm:space-y-0 sm:p-0',
+        isPending && 'opacity-60'
+      )}
+    >
+      <TableCell className="block whitespace-normal break-words p-0 pr-20 font-medium sm:table-cell sm:p-3 sm:pr-3">
         <div>
           <div className="flex items-center flex-wrap gap-1">
             <Link href={`/admin/riders/${participant.riderId}`} className="hover:underline">
@@ -525,7 +542,8 @@ function RiderRow({
           )}
         </div>
       </TableCell>
-      <TableCell>
+      <TableCell className="flex items-center gap-3 p-0 sm:table-cell sm:p-3">
+        <span className={MOBILE_LABEL}>Status</span>
         <Select
           value={localStatus}
           onValueChange={(v) => handleStatusChange(v as ResultStatus)}
@@ -543,7 +561,15 @@ function RiderRow({
           </SelectContent>
         </Select>
       </TableCell>
-      <TableCell>
+      <TableCell
+        className={cn(
+          // The time input is disabled unless the status is "finished", so hide
+          // it in the mobile card until it becomes editable
+          'items-center gap-3 p-0 sm:table-cell sm:p-3',
+          localStatus === 'finished' ? 'flex' : 'hidden'
+        )}
+      >
+        <span className={MOBILE_LABEL}>Time</span>
         <Input
           type="text"
           placeholder="HH:MM"
@@ -557,7 +583,8 @@ function RiderRow({
       </TableCell>
       {isFleche && (
         <>
-          <TableCell>
+          <TableCell className="flex items-center gap-3 p-0 sm:table-cell sm:p-3">
+            <span className={MOBILE_LABEL}>Team</span>
             <Input
               type="text"
               placeholder="Team name"
@@ -569,7 +596,8 @@ function RiderRow({
               className="w-[140px] h-8"
             />
           </TableCell>
-          <TableCell>
+          <TableCell className="flex items-center gap-3 p-0 sm:table-cell sm:p-3">
+            <span className={MOBILE_LABEL}>Distance</span>
             <Input
               type="text"
               placeholder="km"
@@ -583,13 +611,16 @@ function RiderRow({
           </TableCell>
         </>
       )}
-      <TableCell>
+      <TableCell
+        className={cn(
+          // Nothing to show or act on without evidence — omit from the mobile card
+          'items-center gap-3 p-0 sm:table-cell sm:p-3',
+          hasEvidence ? 'flex' : 'hidden'
+        )}
+      >
+        <span className={MOBILE_LABEL}>Evidence</span>
         {/* Evidence - Strava/GPX links, Control Card thumbnails */}
-        {result &&
-        (result.gpx_url ||
-          result.gpx_file_path ||
-          result.control_card_front_path ||
-          result.control_card_back_path) ? (
+        {result && hasEvidence ? (
           <div className="flex items-center gap-1.5">
             {result.gpx_url && (
               <a
@@ -654,13 +685,22 @@ function RiderRow({
           <span className="text-xs text-muted-foreground">—</span>
         )}
       </TableCell>
-      <TableCell className="max-w-[300px] whitespace-normal break-words">
-        {participant.registrationNotes && (
-          <p className="text-muted-foreground">{participant.registrationNotes}</p>
+      <TableCell
+        className={cn(
+          // Full card width on mobile so long notes wrap comfortably
+          'items-start gap-3 whitespace-normal break-words p-0 sm:table-cell sm:max-w-[300px] sm:p-3',
+          hasNotes ? 'flex' : 'hidden'
         )}
-        {result?.rider_notes && <p className="text-muted-foreground">{result.rider_notes}</p>}
+      >
+        <span className={cn(MOBILE_LABEL, 'pt-0.5')}>Note</span>
+        <div className="min-w-0 flex-1 space-y-1">
+          {participant.registrationNotes && (
+            <p className="text-muted-foreground">{participant.registrationNotes}</p>
+          )}
+          {result?.rider_notes && <p className="text-muted-foreground">{result.rider_notes}</p>}
+        </div>
       </TableCell>
-      <TableCell>
+      <TableCell className="absolute top-4 right-4 block p-0 sm:static sm:table-cell sm:p-3">
         <div className="flex items-center gap-1">
           {isPending ? (
             <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
@@ -936,8 +976,8 @@ export function EventResultsManager({
           </p>
         ) : (
           <div className="rounded-md border">
-            <Table>
-              <TableHeader>
+            <Table className="block sm:table">
+              <TableHeader className="hidden sm:table-header-group">
                 <TableRow>
                   <TableHead>Rider</TableHead>
                   <TableHead>Status</TableHead>
@@ -949,7 +989,7 @@ export function EventResultsManager({
                   <TableHead className="w-[50px]"></TableHead>
                 </TableRow>
               </TableHeader>
-              <TableBody>
+              <TableBody className="block sm:table-row-group">
                 {sortedParticipants.map((participant) => (
                   <RiderRow
                     key={participant.id}
@@ -985,24 +1025,30 @@ export function EventResultsManager({
                 Cancelled ({allCancelled.length})
               </h3>
               <div className="rounded-md border">
-                <Table>
-                  <TableHeader>
+                <Table className="block sm:table">
+                  <TableHeader className="hidden sm:table-header-group">
                     <TableRow>
                       <TableHead>Rider</TableHead>
                       <TableHead>Email</TableHead>
                       <TableHead>Cancelled</TableHead>
                     </TableRow>
                   </TableHeader>
-                  <TableBody>
+                  <TableBody className="block sm:table-row-group">
                     {allCancelled.map((reg) => (
-                      <TableRow key={reg.id} className="text-muted-foreground">
-                        <TableCell>
+                      <TableRow
+                        key={reg.id}
+                        className="block p-4 text-muted-foreground sm:table-row sm:p-0"
+                      >
+                        <TableCell className="block p-0 sm:table-cell sm:p-3">
                           {reg.riders
                             ? `${reg.riders.first_name} ${reg.riders.last_name}`
                             : 'Unknown rider'}
                         </TableCell>
-                        <TableCell>{reg.riders?.email ?? '—'}</TableCell>
-                        <TableCell>
+                        <TableCell className="block whitespace-normal break-words p-0 text-xs sm:table-cell sm:p-3 sm:text-sm">
+                          {reg.riders?.email ?? '—'}
+                        </TableCell>
+                        <TableCell className="block p-0 text-xs sm:table-cell sm:p-3 sm:text-sm">
+                          <span className="sm:hidden">Cancelled </span>
                           {reg.cancelled_at
                             ? new Date(reg.cancelled_at).toLocaleDateString('en-CA', {
                                 month: 'short',

--- a/components/admin/events-table.tsx
+++ b/components/admin/events-table.tsx
@@ -1,0 +1,97 @@
+import { parseLocalDate } from '@/lib/utils'
+import { ClickableTableRow } from '@/components/admin/clickable-table-row'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { Badge } from '@/components/ui/badge'
+import type { EventForAdminList } from '@/types/queries'
+
+interface EventsTableProps {
+  events: EventForAdminList[]
+  buildEventDetailUrl: (eventId: string) => string
+}
+
+function getStatusBadge(status: string) {
+  switch (status) {
+    case 'scheduled':
+      return <Badge variant="secondary">Scheduled</Badge>
+    case 'completed':
+      return <Badge>Completed</Badge>
+    case 'submitted':
+      return <Badge className="bg-green-600 hover:bg-green-600">Submitted</Badge>
+    case 'cancelled':
+      return <Badge variant="destructive">Cancelled</Badge>
+    default:
+      return <Badge variant="outline">{status}</Badge>
+  }
+}
+
+export function EventsTable({ events, buildEventDetailUrl }: EventsTableProps) {
+  return (
+    <div className="rounded-md border">
+      <Table className="block sm:table">
+        <TableHeader className="hidden sm:table-header-group">
+          <TableRow>
+            <TableHead>Event</TableHead>
+            <TableHead className="hidden md:table-cell">Chapter</TableHead>
+            <TableHead>Date</TableHead>
+            <TableHead className="hidden sm:table-cell">Distance</TableHead>
+            <TableHead className="hidden sm:table-cell">Riders</TableHead>
+            <TableHead>Status</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody className="block sm:table-row-group">
+          {events.length === 0 ? (
+            <TableRow className="block sm:table-row">
+              <TableCell
+                colSpan={6}
+                className="block p-4 text-center text-muted-foreground sm:table-cell sm:p-3"
+              >
+                No events found
+              </TableCell>
+            </TableRow>
+          ) : (
+            events.map((event) => (
+              <ClickableTableRow
+                key={event.id}
+                href={buildEventDetailUrl(event.id)}
+                className="relative block p-4 sm:table-row sm:p-0"
+              >
+                <TableCell className="block whitespace-normal p-0 pr-28 sm:table-cell sm:p-3 sm:pr-3">
+                  <div>
+                    <span className="font-medium">{event.name}</span>
+                    <p className="text-sm text-muted-foreground capitalize">{event.event_type}</p>
+                  </div>
+                </TableCell>
+                <TableCell className="hidden md:table-cell">
+                  {event.chapters?.name || '—'}
+                </TableCell>
+                <TableCell className="block p-0 pt-1 text-muted-foreground sm:table-cell sm:p-3 sm:text-foreground">
+                  {parseLocalDate(event.event_date).toLocaleDateString('en-CA', {
+                    weekday: 'short',
+                    month: 'short',
+                    day: 'numeric',
+                    year: 'numeric',
+                  })}
+                  <span className="sm:hidden"> · {event.distance_km} km</span>
+                </TableCell>
+                <TableCell className="hidden sm:table-cell">{event.distance_km} km</TableCell>
+                <TableCell className="hidden sm:table-cell tabular-nums">
+                  {event.rider_count ?? 0}
+                </TableCell>
+                <TableCell className="absolute top-4 right-4 block p-0 sm:static sm:table-cell sm:p-3">
+                  {getStatusBadge(event.status ?? 'scheduled')}
+                </TableCell>
+              </ClickableTableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -38,6 +38,8 @@ Each row shows the event name, chapter, date, distance, rider count, and status 
 
 Click any row to open the event detail page.
 
+On phones, event rows stack into cards — name and type up top with the status badge in the corner, and the date and distance below — instead of scrolling sideways. The digital brevet card page's Controls and Check-ins tables stack the same way, with a labelled line per field or control.
+
 ### Creating an event
 
 Click "New Event" in the top right of the Events page. The form asks for:

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -82,6 +82,8 @@ For each rider, you can:
 - **Add a note** if needed.
 - **View rider-submitted evidence**: if a rider submitted their own result, you'll see their GPX file and control card photos.
 
+On phones, the results table converts each rider row into a stacked card with labelled fields (Status, Time, Evidence, Note), so long rider notes wrap at full width instead of forcing the table to scroll sideways. Fields with nothing to show (an empty note, no evidence, or a time input that isn't editable yet) are omitted from the card.
+
 A **First event** badge appears next to riders who have never shown up to a Randonneurs Ontario event before — that is, they have no result recorded for any other event with a status other than DNS. DNF, OTL, DQ, finished, and pending results all count as having shown up, so the badge only highlights brand-new riders. Use it as a heads-up to introduce yourself, walk them through the controls, and make them feel welcome.
 
 You can also add riders using the "Add Rider" button, which is available for both scheduled and completed events. For scheduled events, this adds a registration; for completed events, it adds a result entry. Search by name to find an existing rider, or create a new rider directly from the dialog.

--- a/tests/unit/components/event-checkins-grid.test.tsx
+++ b/tests/unit/components/event-checkins-grid.test.tsx
@@ -393,3 +393,33 @@ describe('formatCheckinDistanceLabel', () => {
     expect(formatCheckinDistanceLabel(1000, null)).toBe('GPS fix recorded 1.0 km from the control')
   })
 })
+
+describe('EventCheckinsGrid mobile card layout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('stacks rider rows into cards with a labelled line per control', () => {
+    render(
+      <EventCheckinsGrid
+        eventId="event-1"
+        eventSubmitted={false}
+        controls={controls}
+        riders={[makeRider({ checkins: [makeCheckin({})] })]}
+      />
+    )
+
+    const row = screen.getByText('Ada Lovelace').closest('tr')!
+    expect(row.className).toContain('block')
+    expect(row.className).toContain('sm:table-row')
+
+    const thead = row.closest('table')!.querySelector('thead')!
+    expect(thead.className).toContain('hidden')
+    expect(thead.className).toContain('sm:table-header-group')
+
+    // Each control cell carries a mobile-only label with the control name and distance
+    const startLabel = screen.getByText('Start · 0 km')
+    expect(startLabel.className).toContain('sm:hidden')
+    expect(screen.getByText('Control 2 · 100 km')).toBeTruthy()
+  })
+})

--- a/tests/unit/components/event-controls-manager.test.tsx
+++ b/tests/unit/components/event-controls-manager.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import { EventControlsManager } from '@/components/admin/event-controls-manager'
 import type { AdminEventControl } from '@/lib/actions/event-controls'
 
@@ -84,5 +84,49 @@ describe('EventControlsManager mount auto-load', () => {
     // Give any (unexpected) effect a chance to fire.
     await Promise.resolve()
     expect(mockImportEventControlsFromRwgps).not.toHaveBeenCalled()
+  })
+})
+
+describe('EventControlsManager mobile card layout', () => {
+  it('stacks control rows into labelled cards on mobile', () => {
+    const { container } = render(
+      <EventControlsManager
+        eventId="event-1"
+        initialControls={[makeSaved({ name: 'Start', checkinCount: 3 })]}
+        hasRwgpsRoute={false}
+      />
+    )
+
+    const thead = container.querySelector('thead')!
+    expect(thead.className).toContain('hidden')
+    expect(thead.className).toContain('sm:table-header-group')
+
+    const row = controlNameInputs()[0].closest('tr')!
+    expect(row.className).toContain('block')
+    expect(row.className).toContain('sm:table-row')
+
+    for (const label of ['Name', 'Km', 'Latitude', 'Longitude', 'Radius (m)', 'Notes']) {
+      const el = within(row).getByText(label)
+      expect(el.className).toContain('sm:hidden')
+    }
+
+    // Check-ins line is present because this control has recorded check-ins
+    const checkinsCell = within(row).getByText('Check-ins').closest('td')!
+    expect(checkinsCell.className).toContain('flex')
+  })
+
+  it('omits the check-ins line from the mobile card when a control has none', () => {
+    render(
+      <EventControlsManager
+        eventId="event-1"
+        initialControls={[makeSaved({ name: 'Start', checkinCount: 0 })]}
+        hasRwgpsRoute={false}
+      />
+    )
+
+    const row = controlNameInputs()[0].closest('tr')!
+    const checkinsCell = within(row).getByText('Check-ins').closest('td')!
+    expect(checkinsCell.className).toContain('hidden')
+    expect(checkinsCell.className).toContain('sm:table-cell')
   })
 })

--- a/tests/unit/components/event-results-manager.test.tsx
+++ b/tests/unit/components/event-results-manager.test.tsx
@@ -253,6 +253,111 @@ describe('EventResultsManager — flèche distance flooring', () => {
   })
 })
 
+describe('EventResultsManager — mobile card layout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const finishedResult: Result = {
+    id: 'result-mobile',
+    rider_id: 'rider-mobile',
+    finish_time: '10:30:00',
+    status: 'finished',
+    team_name: null,
+    distance_km: 200,
+    note: null,
+    gpx_url: 'https://www.strava.com/activities/123',
+    gpx_file_path: null,
+    control_card_front_path: null,
+    control_card_back_path: null,
+    rider_notes: 'Great ride, thanks to the volunteers!',
+    submitted_at: '2026-05-16T00:00:00Z',
+    submission_token: null,
+    riders: {
+      id: 'rider-mobile',
+      first_name: 'Mona',
+      last_name: 'Mobile',
+      email: 'mona@example.com',
+    },
+  }
+
+  it('renders mobile-only field labels for the stacked card layout', () => {
+    render(
+      <EventResultsManager
+        {...baseProps}
+        registrations={[
+          makeRegistration({ riderId: 'rider-mobile', firstName: 'Mona', lastName: 'Mobile' }),
+        ]}
+        results={[finishedResult]}
+        firstTimeRiderIds={[]}
+      />
+    )
+
+    const row = screen.getByText('Mona Mobile').closest('tr')!
+    for (const label of ['Status', 'Time', 'Evidence', 'Note']) {
+      const el = within(row).getByText(label)
+      expect(el.className).toContain('sm:hidden')
+    }
+    expect(within(row).getByText('Great ride, thanks to the volunteers!')).toBeTruthy()
+  })
+
+  it('hides empty Time, Evidence, and Note cells from the mobile card but keeps them on desktop', () => {
+    render(
+      <EventResultsManager
+        {...baseProps}
+        registrations={[
+          makeRegistration({ riderId: 'rider-empty', firstName: 'Edna', lastName: 'Empty' }),
+        ]}
+        firstTimeRiderIds={[]}
+      />
+    )
+
+    const row = screen.getByText('Edna Empty').closest('tr')!
+    const timeCell = within(row).getByPlaceholderText('HH:MM').closest('td')!
+    const evidenceCell = within(row).getByText('Evidence').closest('td')!
+    const noteCell = within(row).getByText('Note').closest('td')!
+
+    for (const cell of [timeCell, evidenceCell, noteCell]) {
+      expect(cell.className).toContain('hidden')
+      expect(cell.className).toContain('sm:table-cell')
+    }
+  })
+
+  it('shows the Time cell in the mobile card once the rider is marked finished', () => {
+    render(
+      <EventResultsManager
+        {...baseProps}
+        registrations={[
+          makeRegistration({ riderId: 'rider-mobile', firstName: 'Mona', lastName: 'Mobile' }),
+        ]}
+        results={[finishedResult]}
+        firstTimeRiderIds={[]}
+      />
+    )
+
+    const row = screen.getByText('Mona Mobile').closest('tr')!
+    const timeCell = within(row).getByPlaceholderText('HH:MM').closest('td')!
+    expect(timeCell.className).toContain('flex')
+    expect(timeCell.className).not.toContain('hidden')
+  })
+
+  it('hides the column header row on mobile', () => {
+    const { container } = render(
+      <EventResultsManager
+        {...baseProps}
+        registrations={[
+          makeRegistration({ riderId: 'rider-1', firstName: 'Alex', lastName: 'Andrews' }),
+        ]}
+        firstTimeRiderIds={[]}
+      />
+    )
+
+    const thead = container.querySelector('thead')!
+    expect(thead.className).toContain('hidden')
+    expect(thead.className).toContain('sm:table-header-group')
+  })
+})
+
 describe('EventResultsManager — rider phone', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/tests/unit/components/events-table.test.tsx
+++ b/tests/unit/components/events-table.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { EventsTable } from '@/components/admin/events-table'
+import type { EventForAdminList } from '@/types/queries'
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+const events: EventForAdminList[] = [
+  {
+    id: 'event-1',
+    name: 'Kissing Bridge',
+    event_date: '2026-07-25',
+    distance_km: 300,
+    event_type: 'brevet',
+    status: 'scheduled',
+    chapter_id: 'chapter-1',
+    chapters: { name: 'Toronto' },
+    rider_count: 5,
+  } as EventForAdminList,
+]
+
+describe('EventsTable', () => {
+  it('renders event rows linking to the detail page', () => {
+    render(<EventsTable events={events} buildEventDetailUrl={(id) => `/admin/events/${id}`} />)
+
+    const row = screen.getByText('Kissing Bridge').closest('tr')!
+    expect(row.getAttribute('role')).toBe('link')
+    expect(screen.getByText('Scheduled')).toBeTruthy()
+  })
+
+  it('renders an empty state when there are no events', () => {
+    render(<EventsTable events={[]} buildEventDetailUrl={(id) => `/admin/events/${id}`} />)
+
+    expect(screen.getByText('No events found')).toBeTruthy()
+  })
+
+  it('stacks rows into cards on mobile: hidden header, block rows, distance inline with date', () => {
+    const { container } = render(
+      <EventsTable events={events} buildEventDetailUrl={(id) => `/admin/events/${id}`} />
+    )
+
+    const thead = container.querySelector('thead')!
+    expect(thead.className).toContain('hidden')
+    expect(thead.className).toContain('sm:table-header-group')
+
+    const row = screen.getByText('Kissing Bridge').closest('tr')!
+    expect(row.className).toContain('block')
+    expect(row.className).toContain('sm:table-row')
+
+    // Distance rides along with the date on mobile (the Distance column is sm-only)
+    const mobileDistance = screen.getByText(/· 300 km/)
+    expect(mobileDistance.className).toContain('sm:hidden')
+
+    // Status badge is pinned to the card's top-right corner on mobile
+    const statusCell = screen.getByText('Scheduled').closest('td')!
+    expect(statusCell.className).toContain('absolute')
+    expect(statusCell.className).toContain('sm:static')
+  })
+})


### PR DESCRIPTION
The Registrations & Results table on the admin event detail page forced
horizontal scrolling on phones, and long rider notes were squeezed into a
narrow column that wrapped one word per line. Convert each row to a
stacked card with labelled fields below the sm breakpoint, per the style
guide's table cardification pattern:

- Rider info first with the row actions pinned top-right
- Status, Time, Evidence, and Note as label/value pairs; notes wrap at
  full card width
- Empty fields (no note, no evidence, time input not yet editable) are
  omitted from the card
- Column headers hidden on mobile; the cancelled registrations table
  stacks the same way
- Desktop table layout is unchanged from sm up

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FtPwhSKwbSnVS6xSuxNrpG