### PR TITLE
Extract shared registration form hook, components, and storage (#82)

### DIFF
--- a/components/control-card-form.tsx
+++ b/components/control-card-form.tsx
@@ -19,6 +19,7 @@ import {
 import { Plus, Trash2, Printer, GripVertical, Download, Loader2, ChevronDown } from 'lucide-react'
 import type { ActiveRouteWithRwgps } from '@/lib/data/routes'
 import { fetchRwgpsControls, fetchRwgpsRoute, parseRwgpsRouteRef } from '@/lib/rwgps'
+import { getSavedRegistrationData } from '@/lib/registration-storage'
 
 interface ControlInput {
   id: string
@@ -32,21 +33,12 @@ interface RiderInput {
   lastName: string
 }
 
-const STORAGE_KEY = 'ro-registration'
-
 function getSavedRiderData(): { firstName: string; lastName: string } | null {
-  if (typeof window === 'undefined') return null
-  try {
-    const saved = localStorage.getItem(STORAGE_KEY)
-    if (!saved) return null
-    const data = JSON.parse(saved)
-    if (data.firstName || data.lastName) {
-      return { firstName: data.firstName || '', lastName: data.lastName || '' }
-    }
-    return null
-  } catch {
-    return null
+  const data = getSavedRegistrationData()
+  if (data && (data.firstName || data.lastName)) {
+    return { firstName: data.firstName || '', lastName: data.lastName || '' }
   }
+  return null
 }
 
 interface ControlCardFormProps {

--- a/components/fleche-registration-form.tsx
+++ b/components/fleche-registration-form.tsx
@@ -1,12 +1,8 @@
 'use client'
 
-import { useState, useTransition, useEffect, useRef } from 'react'
-import { useRouter } from 'next/navigation'
-import Link from 'next/link'
+import { useState } from 'react'
 import { Input } from '@/components/ui/input'
-import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
-import { Checkbox } from '@/components/ui/checkbox'
 import { Button } from '@/components/ui/button'
 import {
   Select,
@@ -15,17 +11,24 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { AlertTriangle } from 'lucide-react'
 import { registerForEvent, completeRegistrationWithRider } from '@/lib/actions/register'
-import { RiderMatchDialog } from '@/components/rider-match-dialog'
-import type { RiderMatchCandidate } from '@/lib/actions/rider-match'
-import { getUpcomingEventsByEventId, type UpcomingEvent } from '@/lib/actions/rider-results'
-import { format } from 'date-fns'
-import { ArrowRight, AlertTriangle } from 'lucide-react'
-import { MembershipErrorModal } from '@/components/membership-error-modal'
 import { HoneypotField } from '@/components/honeypot-field'
-import { EmailTypoSuggestion } from '@/components/email-typo-suggestion'
 import type { FlecheTeam } from '@/lib/data/events'
-import { getSavedRegistrationData, saveRegistrationData } from '@/lib/registration-storage'
+import { useRegistrationForm } from '@/hooks/use-registration-form'
+import {
+  RegistrationError,
+  RiderInfoFields,
+  EmergencyContactFields,
+  ShareRegistrationCheckbox,
+  NotesField,
+} from '@/components/registration/registration-fields'
+import {
+  RegistrationSuccess,
+  UpcomingEventsLoading,
+  UpcomingEventsSection,
+} from '@/components/registration/registration-success'
+import { RegistrationDialogs } from '@/components/registration/registration-dialogs'
 
 interface FlecheRegistrationFormProps {
   eventId: string
@@ -39,8 +42,8 @@ export function FlecheRegistrationForm({
   existingTeams,
   variant = 'card',
 }: FlecheRegistrationFormProps) {
-  const router = useRouter()
-  const [isPending, startTransition] = useTransition()
+  const form = useRegistrationForm({ upcomingEventsEventId: eventId })
+  const { isPending, startTransition } = form
 
   // Team state
   const [teamMode, setTeamMode] = useState<'create' | 'join'>(
@@ -48,76 +51,17 @@ export function FlecheRegistrationForm({
   )
   const [newTeamName, setNewTeamName] = useState('')
   const [selectedTeam, setSelectedTeam] = useState('')
-
-  // Personal details state
-  const [firstName, setFirstName] = useState('')
-  const [lastName, setLastName] = useState('')
-  const [email, setEmail] = useState('')
-  const [blurredEmail, setBlurredEmail] = useState('')
-  const [phone, setPhone] = useState('')
-  const [shareRegistration, setShareRegistration] = useState(true)
-  const [gender, setGender] = useState<string>('')
-  const [emergencyContactName, setEmergencyContactName] = useState('')
-  const [emergencyContactPhone, setEmergencyContactPhone] = useState('')
-  const [homepageUrl, setHomepageUrl] = useState('')
-  const [error, setError] = useState<string | null>(null)
-  const [success, setSuccess] = useState(false)
-
-  // Membership error state
-  const [membershipErrorVariant, setMembershipErrorVariant] = useState<
-    'no-membership' | 'trial-used' | null
-  >(null)
-
-  // Fuzzy matching state
-  const [matchDialogOpen, setMatchDialogOpen] = useState(false)
-  const [matchCandidates, setMatchCandidates] = useState<RiderMatchCandidate[]>([])
-  const [pendingNotes, setPendingNotes] = useState<string>('')
-
-  // Upcoming events state
-  const [upcomingEvents, setUpcomingEvents] = useState<UpcomingEvent[]>([])
-  const [loadingEvents, setLoadingEvents] = useState(false)
-
-  const errorRef = useRef<HTMLDivElement>(null)
-  const successRef = useRef<HTMLDivElement>(null)
-
-  // Load saved data on mount
-  useEffect(() => {
-    const saved = getSavedRegistrationData()
-    if (saved) {
-      setFirstName(saved.firstName)
-      setLastName(saved.lastName)
-      setEmail(saved.email)
-      setPhone(saved.phone || '')
-      setGender(saved.gender)
-      setShareRegistration(saved.shareRegistration)
-      setEmergencyContactName(saved.emergencyContactName || '')
-      setEmergencyContactPhone(saved.emergencyContactPhone || '')
-    }
-  }, [])
-
-  // Scroll error into view when it appears
-  useEffect(() => {
-    if (error && errorRef.current) {
-      errorRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
-    }
-  }, [error])
-
-  // Move focus to success message when registration completes
-  useEffect(() => {
-    if (success && successRef.current) {
-      successRef.current.focus()
-    }
-  }, [success])
+  const [pendingNotes, setPendingNotes] = useState('')
 
   const resolvedTeamName = teamMode === 'create' ? newTeamName.trim() : selectedTeam
   const selectedTeamInfo = existingTeams.find((t) => t.teamName === selectedTeam)
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
-    setError(null)
+    form.setError(null)
 
     if (!resolvedTeamName) {
-      setError(teamMode === 'create' ? 'Please enter a team name' : 'Please select a team')
+      form.setError(teamMode === 'create' ? 'Please enter a team name' : 'Please select a team')
       return
     }
 
@@ -127,95 +71,28 @@ export function FlecheRegistrationForm({
     startTransition(async () => {
       const result = await registerForEvent({
         eventId,
-        firstName,
-        lastName,
-        email,
-        phone,
-        gender: gender || undefined,
-        shareRegistration,
+        ...form.riderPayload,
         notes: notes || undefined,
-        emergencyContactName,
-        emergencyContactPhone,
         teamName: resolvedTeamName,
         isTeamCaptain: teamMode === 'create',
-        homepageUrl,
       })
-
-      if (result.success) {
-        saveRegistrationData({
-          firstName,
-          lastName,
-          email,
-          phone,
-          gender,
-          shareRegistration,
-          emergencyContactName,
-          emergencyContactPhone,
-        })
-        setSuccess(true)
-        router.refresh()
-
-        setLoadingEvents(true)
-        getUpcomingEventsByEventId(eventId, 3)
-          .then((eventsResult) => {
-            if (eventsResult.success && eventsResult.data) {
-              setUpcomingEvents(eventsResult.data)
-            }
-          })
-          .catch(() => {})
-          .finally(() => setLoadingEvents(false))
-      } else if (result.needsRiderMatch && result.matchCandidates) {
-        setMatchCandidates(result.matchCandidates)
-        setPendingNotes(notes || '')
-        setMatchDialogOpen(true)
-      } else if (result.membershipError) {
-        setMembershipErrorVariant(result.membershipError)
-      } else {
-        setError(result.error || 'Registration failed')
-      }
+      form.handleRegistrationResult(result, {
+        onNeedsMatch: () => setPendingNotes(notes || ''),
+      })
     })
   }
 
-  async function handleRiderSelection(riderId: string | null) {
+  function handleRiderSelection(riderId: string | null) {
     startTransition(async () => {
       const result = await completeRegistrationWithRider({
         eventId,
         selectedRiderId: riderId,
-        firstName,
-        lastName,
-        email,
-        phone,
-        gender: gender || undefined,
-        shareRegistration,
+        ...form.riderPayload,
         notes: pendingNotes || undefined,
-        emergencyContactName,
-        emergencyContactPhone,
         teamName: resolvedTeamName,
         isTeamCaptain: teamMode === 'create',
-        homepageUrl,
       })
-
-      if (result.success) {
-        setMatchDialogOpen(false)
-        saveRegistrationData({
-          firstName,
-          lastName,
-          email,
-          phone,
-          gender,
-          shareRegistration,
-          emergencyContactName,
-          emergencyContactPhone,
-        })
-        setSuccess(true)
-        router.refresh()
-      } else if (result.membershipError) {
-        setMatchDialogOpen(false)
-        setMembershipErrorVariant(result.membershipError)
-      } else {
-        setMatchDialogOpen(false)
-        setError(result.error || 'Registration failed')
-      }
+      form.handleRegistrationResult(result)
     })
   }
 
@@ -224,57 +101,17 @@ export function FlecheRegistrationForm({
       ? 'lg:sticky lg:top-24 rounded-2xl border border-border bg-card p-6 md:p-8'
       : undefined
 
-  if (success) {
+  if (form.success) {
     return (
       <div className={wrapperClassName}>
-        <div
-          ref={successRef}
-          tabIndex={-1}
-          role="status"
-          className="text-center py-8"
-          data-testid="registration-success"
-        >
-          <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-green-100 dark:bg-green-900/30 mb-4">
-            <svg
-              aria-hidden="true"
-              className="w-6 h-6 text-green-600 dark:text-green-400"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M5 13l4 4L19 7"
-              />
-            </svg>
-          </div>
-          <h2 className="font-serif text-2xl tracking-tight mb-2">You're registered!</h2>
-          <p className="text-sm text-muted-foreground">Team: {resolvedTeamName}</p>
-        </div>
+        <RegistrationSuccess successRef={form.successRef} title="You're registered!">
+          Team: {resolvedTeamName}
+        </RegistrationSuccess>
 
-        {loadingEvents && (
-          <div className="border-t border-border pt-6 mt-6" role="status">
-            <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
-              <div
-                className="w-4 h-4 border-2 border-muted-foreground border-t-transparent rounded-full animate-spin"
-                aria-hidden="true"
-              />
-              Loading upcoming events…
-            </div>
-          </div>
-        )}
+        {form.loadingEvents && <UpcomingEventsLoading />}
 
-        {!loadingEvents && upcomingEvents.length > 0 && (
-          <div className="border-t border-border pt-6 mt-6">
-            <h3 className="font-medium text-sm mb-4 text-center">More Upcoming Events</h3>
-            <div className="space-y-3">
-              {upcomingEvents.map((event) => (
-                <UpcomingEventCard key={event.id} event={event} />
-              ))}
-            </div>
-          </div>
+        {!form.loadingEvents && form.upcomingEvents.length > 0 && (
+          <UpcomingEventsSection title="More Upcoming Events" events={form.upcomingEvents} />
         )}
       </div>
     )
@@ -285,17 +122,8 @@ export function FlecheRegistrationForm({
       {variant === 'card' && <h2 className="font-serif text-2xl tracking-tight mb-6">Register</h2>}
 
       <form className="space-y-5" onSubmit={handleSubmit}>
-        <HoneypotField value={homepageUrl} onChange={setHomepageUrl} />
-        {error && (
-          <div
-            ref={errorRef}
-            role="alert"
-            className="p-3 rounded-lg bg-destructive/10 text-destructive text-sm"
-            data-testid="registration-error"
-          >
-            {error}
-          </div>
-        )}
+        <HoneypotField value={form.homepageUrl} onChange={form.setHomepageUrl} />
+        <RegistrationError form={form} />
 
         {/* Team Section */}
         <fieldset className="space-y-4">
@@ -376,189 +204,11 @@ export function FlecheRegistrationForm({
 
         <div className="border-t border-border pt-5" />
 
-        {/* Name */}
-        <div className="grid grid-cols-1 min-[400px]:grid-cols-2 gap-4">
-          <div className="space-y-2">
-            <Label htmlFor="firstName">First name</Label>
-            <Input
-              id="firstName"
-              name="firstName"
-              type="text"
-              placeholder="First"
-              required
-              autoComplete="given-name"
-              disabled={isPending}
-              value={firstName}
-              onChange={(e) => setFirstName(e.target.value)}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="lastName">Last name</Label>
-            <Input
-              id="lastName"
-              name="lastName"
-              type="text"
-              placeholder="Last"
-              required
-              autoComplete="family-name"
-              disabled={isPending}
-              value={lastName}
-              onChange={(e) => setLastName(e.target.value)}
-            />
-          </div>
-        </div>
+        <RiderInfoFields form={form} />
+        <EmergencyContactFields form={form} />
+        <NotesField disabled={isPending} />
+        <ShareRegistrationCheckbox form={form} />
 
-        {/* Email */}
-        <div className="space-y-2">
-          <Label htmlFor="email">Email address</Label>
-          <Input
-            id="email"
-            name="email"
-            type="email"
-            inputMode="email"
-            placeholder="you@example.com"
-            required
-            autoComplete="email"
-            disabled={isPending}
-            value={email}
-            onChange={(e) => {
-              setEmail(e.target.value)
-              setBlurredEmail('')
-            }}
-            onBlur={(e) => setBlurredEmail(e.target.value)}
-          />
-          <EmailTypoSuggestion
-            email={blurredEmail}
-            onAccept={(corrected) => {
-              setEmail(corrected)
-              setBlurredEmail('')
-            }}
-          />
-        </div>
-
-        {/* Cell phone */}
-        <div className="space-y-2">
-          <Label htmlFor="phone">Cell phone</Label>
-          <Input
-            id="phone"
-            name="phone"
-            type="tel"
-            inputMode="tel"
-            placeholder="Phone number"
-            required
-            autoComplete="tel"
-            disabled={isPending}
-            value={phone}
-            onChange={(e) => setPhone(e.target.value)}
-          />
-          <p className="text-xs text-muted-foreground">
-            Used only for urgent ride-day updates, such as weather or safety-related changes.
-          </p>
-        </div>
-
-        {/* Gender */}
-        <div className="space-y-2">
-          <Label htmlFor="gender">
-            Gender
-            <span className="text-muted-foreground font-normal ml-1">(optional)</span>
-          </Label>
-          <Select
-            key={gender || 'empty'}
-            value={gender}
-            onValueChange={setGender}
-            disabled={isPending}
-          >
-            <SelectTrigger id="gender" className="w-full">
-              <SelectValue placeholder="Select…" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="M">Male</SelectItem>
-              <SelectItem value="F">Female</SelectItem>
-              <SelectItem value="X">Non-binary / Other</SelectItem>
-            </SelectContent>
-          </Select>
-          <p className="text-xs text-muted-foreground">
-            Audax Club Parisien uses this for ridership statistics.
-          </p>
-        </div>
-
-        {/* Emergency Contact */}
-        <fieldset className="bg-muted/50 border border-border rounded-lg p-4 space-y-3">
-          <legend className="text-sm font-medium">Emergency contact</legend>
-          <div className="grid grid-cols-1 min-[400px]:grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label htmlFor="emergencyContactName">Name</Label>
-              <Input
-                id="emergencyContactName"
-                name="emergencyContactName"
-                type="text"
-                placeholder="Name"
-                required
-                autoComplete="off"
-                disabled={isPending}
-                value={emergencyContactName}
-                onChange={(e) => setEmergencyContactName(e.target.value)}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="emergencyContactPhone">Phone</Label>
-              <Input
-                id="emergencyContactPhone"
-                name="emergencyContactPhone"
-                type="tel"
-                inputMode="tel"
-                placeholder="Phone number"
-                required
-                autoComplete="off"
-                disabled={isPending}
-                value={emergencyContactPhone}
-                onChange={(e) => setEmergencyContactPhone(e.target.value)}
-              />
-            </div>
-          </div>
-        </fieldset>
-
-        {/* Notes */}
-        <div className="space-y-2">
-          <Label htmlFor="notes">
-            Notes for the organizer
-            <span className="text-muted-foreground font-normal ml-1">(optional)</span>
-          </Label>
-          <Textarea
-            id="notes"
-            name="notes"
-            placeholder="Any special requirements or information…"
-            rows={3}
-            disabled={isPending}
-          />
-        </div>
-
-        {/* Share Registration */}
-        <div className="flex items-start gap-3">
-          <Checkbox
-            checked={shareRegistration}
-            onCheckedChange={(checked) => setShareRegistration(checked === true)}
-            className="mt-1"
-            disabled={isPending}
-            aria-label="Appear on the registered riders list"
-          />
-          {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- checkbox is keyboard-accessible via aria-label */}
-          <div
-            className="space-y-1 cursor-pointer"
-            onClick={() => {
-              if (!isPending) setShareRegistration((v) => !v)
-            }}
-          >
-            <span className="text-sm font-medium leading-none">
-              Appear on the registered riders list
-            </span>
-            <p className="text-xs text-muted-foreground">
-              Allow other riders to see you're signed up. Results always include all riders.
-            </p>
-          </div>
-        </div>
-
-        {/* Submit */}
         <Button
           type="submit"
           className="w-full h-12"
@@ -570,56 +220,7 @@ export function FlecheRegistrationForm({
         </Button>
       </form>
 
-      <RiderMatchDialog
-        open={matchDialogOpen}
-        onOpenChange={setMatchDialogOpen}
-        candidates={matchCandidates}
-        submittedFirstName={firstName}
-        submittedLastName={lastName}
-        onSelectRider={(riderId) => handleRiderSelection(riderId)}
-        onCreateNew={() => handleRiderSelection(null)}
-        isPending={isPending}
-      />
-
-      <MembershipErrorModal
-        open={membershipErrorVariant !== null}
-        onClose={() => setMembershipErrorVariant(null)}
-        variant={membershipErrorVariant || 'no-membership'}
-      />
-    </div>
-  )
-}
-
-interface UpcomingEventCardProps {
-  event: UpcomingEvent
-}
-
-function UpcomingEventCard({ event }: UpcomingEventCardProps) {
-  return (
-    <div className="flex items-center gap-4 p-3 rounded-lg border border-border bg-muted/30">
-      <div className="flex-shrink-0 text-center w-14">
-        <div className="text-xs text-muted-foreground uppercase">
-          {format(new Date(event.date + 'T00:00:00'), 'MMM')}
-        </div>
-        <div className="text-lg font-medium tabular-nums">
-          {format(new Date(event.date + 'T00:00:00'), 'd')}
-        </div>
-      </div>
-      <div className="flex-1 min-w-0">
-        <div className="font-medium text-sm truncate">{event.name}</div>
-        <div className="text-xs text-muted-foreground mt-0.5 tabular-nums">{event.distance} km</div>
-        {event.startLocation && (
-          <div className="text-xs text-muted-foreground truncate">{event.startLocation}</div>
-        )}
-      </div>
-      <Link
-        href={`/register/${event.slug}`}
-        className="flex-shrink-0 inline-flex items-center gap-1 text-sm text-primary hover:underline"
-        aria-label={`Register for ${event.name}`}
-      >
-        Register
-        <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
-      </Link>
+      <RegistrationDialogs form={form} onSelectRider={handleRiderSelection} />
     </div>
   )
 }

--- a/components/fleche-registration-form.tsx
+++ b/components/fleche-registration-form.tsx
@@ -25,37 +25,7 @@ import { MembershipErrorModal } from '@/components/membership-error-modal'
 import { HoneypotField } from '@/components/honeypot-field'
 import { EmailTypoSuggestion } from '@/components/email-typo-suggestion'
 import type { FlecheTeam } from '@/lib/data/events'
-
-const STORAGE_KEY = 'ro-registration'
-
-interface SavedRegistrationData {
-  firstName: string
-  lastName: string
-  email: string
-  phone: string
-  gender: string
-  shareRegistration: boolean
-  emergencyContactName: string
-  emergencyContactPhone: string
-}
-
-function getSavedData(): SavedRegistrationData | null {
-  if (typeof window === 'undefined') return null
-  try {
-    const saved = localStorage.getItem(STORAGE_KEY)
-    return saved ? JSON.parse(saved) : null
-  } catch {
-    return null
-  }
-}
-
-function saveData(data: SavedRegistrationData): void {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
-  } catch {
-    // Ignore storage errors
-  }
-}
+import { getSavedRegistrationData, saveRegistrationData } from '@/lib/registration-storage'
 
 interface FlecheRegistrationFormProps {
   eventId: string
@@ -112,7 +82,7 @@ export function FlecheRegistrationForm({
 
   // Load saved data on mount
   useEffect(() => {
-    const saved = getSavedData()
+    const saved = getSavedRegistrationData()
     if (saved) {
       setFirstName(saved.firstName)
       setLastName(saved.lastName)
@@ -172,7 +142,7 @@ export function FlecheRegistrationForm({
       })
 
       if (result.success) {
-        saveData({
+        saveRegistrationData({
           firstName,
           lastName,
           email,
@@ -227,7 +197,7 @@ export function FlecheRegistrationForm({
 
       if (result.success) {
         setMatchDialogOpen(false)
-        saveData({
+        saveRegistrationData({
           firstName,
           lastName,
           email,

--- a/components/my-rides-section.tsx
+++ b/components/my-rides-section.tsx
@@ -3,8 +3,8 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { getMyUpcomingRides, type MyUpcomingRide } from '@/lib/actions/my-rides'
+import { getSavedRegistrationData } from '@/lib/registration-storage'
 
-const STORAGE_KEY = 'ro-registration'
 const MAX_COLLAPSED = 3
 
 function formatDate(dateString: string): { month: string; day: string } {
@@ -20,23 +20,16 @@ export function MyRidesSection() {
   const [expanded, setExpanded] = useState(false)
 
   useEffect(() => {
-    try {
-      const saved = localStorage.getItem(STORAGE_KEY)
-      if (!saved) return
+    const data = getSavedRegistrationData()
+    if (!data?.email) return
 
-      const data = JSON.parse(saved)
-      if (!data?.email) return
+    setFirstName(data.firstName || '')
 
-      setFirstName(data.firstName || '')
-
-      getMyUpcomingRides(data.email).then((result) => {
-        if (result.success && result.data && result.data.length > 0) {
-          setRides(result.data)
-        }
-      })
-    } catch {
-      // Corrupted localStorage — render nothing
-    }
+    getMyUpcomingRides(data.email).then((result) => {
+      if (result.success && result.data && result.data.length > 0) {
+        setRides(result.data)
+      }
+    })
   }, [])
 
   if (!rides || rides.length === 0) return null

--- a/components/permanent-registration-form.tsx
+++ b/components/permanent-registration-form.tsx
@@ -33,37 +33,7 @@ import type { RiderMatchCandidate } from '@/lib/actions/rider-match'
 import type { ActiveRoute } from '@/lib/data/routes'
 import { HoneypotField } from '@/components/honeypot-field'
 import { EmailTypoSuggestion } from '@/components/email-typo-suggestion'
-
-const STORAGE_KEY = 'ro-registration'
-
-interface SavedRegistrationData {
-  firstName: string
-  lastName: string
-  email: string
-  phone: string
-  gender: string
-  shareRegistration: boolean
-  emergencyContactName: string
-  emergencyContactPhone: string
-}
-
-function getSavedData(): SavedRegistrationData | null {
-  if (typeof window === 'undefined') return null
-  try {
-    const saved = localStorage.getItem(STORAGE_KEY)
-    return saved ? JSON.parse(saved) : null
-  } catch {
-    return null
-  }
-}
-
-function saveData(data: SavedRegistrationData): void {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
-  } catch {
-    // Ignore storage errors
-  }
-}
+import { getSavedRegistrationData, saveRegistrationData } from '@/lib/registration-storage'
 
 const TORONTO_TZ = 'America/Toronto'
 
@@ -154,7 +124,7 @@ export function PermanentRegistrationForm({ routes }: PermanentRegistrationFormP
 
   // Load saved data on mount
   useEffect(() => {
-    const saved = getSavedData()
+    const saved = getSavedRegistrationData()
     if (saved) {
       setFirstName(saved.firstName)
       setLastName(saved.lastName)
@@ -221,7 +191,7 @@ export function PermanentRegistrationForm({ routes }: PermanentRegistrationFormP
 
       if (result.success) {
         // Save form data to localStorage for next registration
-        saveData({
+        saveRegistrationData({
           firstName,
           lastName,
           email,
@@ -265,7 +235,7 @@ export function PermanentRegistrationForm({ routes }: PermanentRegistrationFormP
 
       if (result.success) {
         setMatchDialogOpen(false)
-        saveData({
+        saveRegistrationData({
           firstName,
           lastName,
           email,

--- a/components/permanent-registration-form.tsx
+++ b/components/permanent-registration-form.tsx
@@ -1,13 +1,10 @@
 'use client'
 
-import { useState, useTransition, useEffect, useMemo, useRef } from 'react'
-import { useRouter } from 'next/navigation'
+import { useState, useMemo } from 'react'
 import { ChevronDownIcon } from 'lucide-react'
 import { format, addDays, isBefore } from 'date-fns'
 import { Input } from '@/components/ui/input'
-import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
-import { Checkbox } from '@/components/ui/checkbox'
 import { Button } from '@/components/ui/button'
 import { Calendar } from '@/components/ui/calendar'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
@@ -27,13 +24,18 @@ import {
   CommandList,
 } from '@/components/ui/command'
 import { registerForPermanent, completeRegistrationWithRider } from '@/lib/actions/register'
-import { RiderMatchDialog } from '@/components/rider-match-dialog'
-import { MembershipErrorModal } from '@/components/membership-error-modal'
-import type { RiderMatchCandidate } from '@/lib/actions/rider-match'
 import type { ActiveRoute } from '@/lib/data/routes'
 import { HoneypotField } from '@/components/honeypot-field'
-import { EmailTypoSuggestion } from '@/components/email-typo-suggestion'
-import { getSavedRegistrationData, saveRegistrationData } from '@/lib/registration-storage'
+import { useRegistrationForm } from '@/hooks/use-registration-form'
+import {
+  RegistrationError,
+  RiderInfoFields,
+  EmergencyContactFields,
+  ShareRegistrationCheckbox,
+  NotesField,
+} from '@/components/registration/registration-fields'
+import { RegistrationSuccess } from '@/components/registration/registration-success'
+import { RegistrationDialogs } from '@/components/registration/registration-dialogs'
 
 const TORONTO_TZ = 'America/Toronto'
 
@@ -66,8 +68,8 @@ interface PermanentRegistrationFormProps {
 }
 
 export function PermanentRegistrationForm({ routes }: PermanentRegistrationFormProps) {
-  const router = useRouter()
-  const [isPending, startTransition] = useTransition()
+  const form = useRegistrationForm()
+  const { isPending, startTransition } = form
 
   // Route/schedule fields
   const [routeId, setRouteId] = useState<string>('')
@@ -77,36 +79,10 @@ export function PermanentRegistrationForm({ routes }: PermanentRegistrationFormP
   const [startTime, setStartTime] = useState<string>('08:00')
   const [startLocation, setStartLocation] = useState<string>('')
   const [direction, setDirection] = useState<'as_posted' | 'reversed'>('as_posted')
-
-  // Rider fields
-  const [firstName, setFirstName] = useState('')
-  const [lastName, setLastName] = useState('')
-  const [email, setEmail] = useState('')
-  const [blurredEmail, setBlurredEmail] = useState('')
-  const [phone, setPhone] = useState('')
-  const [shareRegistration, setShareRegistration] = useState(true)
-  const [gender, setGender] = useState<string>('')
-  const [emergencyContactName, setEmergencyContactName] = useState('')
-  const [emergencyContactPhone, setEmergencyContactPhone] = useState('')
   const [notes, setNotes] = useState('')
-  const [homepageUrl, setHomepageUrl] = useState('')
 
-  // UI state
-  const [error, setError] = useState<string | null>(null)
-  const [success, setSuccess] = useState(false)
-
-  // Membership error state
-  const [membershipErrorVariant, setMembershipErrorVariant] = useState<
-    'no-membership' | 'trial-used' | null
-  >(null)
-
-  // Fuzzy matching state
-  const [matchDialogOpen, setMatchDialogOpen] = useState(false)
-  const [matchCandidates, setMatchCandidates] = useState<RiderMatchCandidate[]>([])
+  // Fuzzy matching context: the event created before the rider match was needed
   const [pendingEventId, setPendingEventId] = useState<string>('')
-
-  const errorRef = useRef<HTMLDivElement>(null)
-  const successRef = useRef<HTMLDivElement>(null)
 
   // Group routes by chapter
   const routesByChapter = useMemo(() => {
@@ -122,48 +98,19 @@ export function PermanentRegistrationForm({ routes }: PermanentRegistrationFormP
     return Object.entries(grouped).sort(([a], [b]) => a.localeCompare(b))
   }, [routes])
 
-  // Load saved data on mount
-  useEffect(() => {
-    const saved = getSavedRegistrationData()
-    if (saved) {
-      setFirstName(saved.firstName)
-      setLastName(saved.lastName)
-      setEmail(saved.email)
-      setPhone(saved.phone || '')
-      setGender(saved.gender)
-      setShareRegistration(saved.shareRegistration)
-      setEmergencyContactName(saved.emergencyContactName || '')
-      setEmergencyContactPhone(saved.emergencyContactPhone || '')
-    }
-  }, [])
-
-  // Scroll error into view when it appears
-  useEffect(() => {
-    if (error && errorRef.current) {
-      errorRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
-    }
-  }, [error])
-
-  // Move focus to success message when registration completes
-  useEffect(() => {
-    if (success && successRef.current) {
-      successRef.current.focus()
-    }
-  }, [success])
-
   const selectedRoute = routes.find((r) => r.id === routeId)
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
-    setError(null)
+    form.setError(null)
 
     if (!routeId) {
-      setError('Please select a route')
+      form.setError('Please select a route')
       return
     }
 
     if (!eventDate) {
-      setError('Please select a date')
+      form.setError('Please select a date')
       return
     }
 
@@ -177,117 +124,35 @@ export function PermanentRegistrationForm({ routes }: PermanentRegistrationFormP
         startTime,
         startLocation: startLocation.trim(),
         direction,
-        firstName,
-        lastName,
-        email,
-        phone,
-        gender: gender || undefined,
-        shareRegistration,
+        ...form.riderPayload,
         notes: notes || undefined,
-        emergencyContactName,
-        emergencyContactPhone,
-        homepageUrl,
       })
-
-      if (result.success) {
-        // Save form data to localStorage for next registration
-        saveRegistrationData({
-          firstName,
-          lastName,
-          email,
-          phone,
-          gender,
-          shareRegistration,
-          emergencyContactName,
-          emergencyContactPhone,
-        })
-        setSuccess(true)
-        router.refresh()
-      } else if (result.needsRiderMatch && result.matchCandidates && result.pendingData) {
-        // Show fuzzy matching dialog
-        setMatchCandidates(result.matchCandidates)
-        setPendingEventId(result.pendingData.eventId)
-        setMatchDialogOpen(true)
-      } else if (result.membershipError) {
-        setMembershipErrorVariant(result.membershipError)
-      } else {
-        setError(result.error || 'Registration failed')
-      }
+      form.handleRegistrationResult(result, {
+        onNeedsMatch: (r) => {
+          if (r.pendingData) setPendingEventId(r.pendingData.eventId)
+        },
+      })
     })
   }
 
-  async function handleRiderSelection(riderId: string | null) {
+  function handleRiderSelection(riderId: string | null) {
     startTransition(async () => {
       const result = await completeRegistrationWithRider({
         eventId: pendingEventId,
         selectedRiderId: riderId,
-        firstName,
-        lastName,
-        email,
-        phone,
-        gender: gender || undefined,
-        shareRegistration,
+        ...form.riderPayload,
         notes: notes || undefined,
-        emergencyContactName,
-        emergencyContactPhone,
-        homepageUrl,
       })
-
-      if (result.success) {
-        setMatchDialogOpen(false)
-        saveRegistrationData({
-          firstName,
-          lastName,
-          email,
-          phone,
-          gender,
-          shareRegistration,
-          emergencyContactName,
-          emergencyContactPhone,
-        })
-        setSuccess(true)
-        router.refresh()
-      } else if (result.membershipError) {
-        setMatchDialogOpen(false)
-        setMembershipErrorVariant(result.membershipError)
-      } else {
-        setMatchDialogOpen(false)
-        setError(result.error || 'Registration failed')
-      }
+      form.handleRegistrationResult(result)
     })
   }
 
-  if (success) {
+  if (form.success) {
     return (
       <div className="rounded-2xl border border-border bg-card p-6 md:p-8">
-        <div
-          ref={successRef}
-          tabIndex={-1}
-          role="status"
-          className="text-center py-8"
-          data-testid="registration-success"
-        >
-          <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-green-100 dark:bg-green-900/30 mb-4">
-            <svg
-              className="w-6 h-6 text-green-600 dark:text-green-400"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M5 13l4 4L19 7"
-              />
-            </svg>
-          </div>
-          <h2 className="font-serif text-2xl mb-2">You&apos;re registered!</h2>
-          <p className="text-sm text-muted-foreground">
-            Your permanent ride has been scheduled. You&apos;ll receive a confirmation email
-            shortly.
-          </p>
-        </div>
+        <RegistrationSuccess successRef={form.successRef} title="You're registered!">
+          Your permanent ride has been scheduled. You&apos;ll receive a confirmation email shortly.
+        </RegistrationSuccess>
       </div>
     )
   }
@@ -297,17 +162,8 @@ export function PermanentRegistrationForm({ routes }: PermanentRegistrationFormP
       <h2 className="font-serif text-2xl mb-6">Schedule Your Ride</h2>
 
       <form className="space-y-6" onSubmit={handleSubmit}>
-        <HoneypotField value={homepageUrl} onChange={setHomepageUrl} />
-        {error && (
-          <div
-            ref={errorRef}
-            role="alert"
-            className="p-3 rounded-lg bg-destructive/10 text-destructive text-sm"
-            data-testid="registration-error"
-          >
-            {error}
-          </div>
-        )}
+        <HoneypotField value={form.homepageUrl} onChange={form.setHomepageUrl} />
+        <RegistrationError form={form} />
 
         {/* Route Selection Section */}
         <div className="space-y-5">
@@ -467,189 +323,10 @@ export function PermanentRegistrationForm({ routes }: PermanentRegistrationFormP
             Your Information
           </h3>
 
-          {/* Name */}
-          <div className="grid grid-cols-1 min-[400px]:grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label htmlFor="firstName">First name</Label>
-              <Input
-                id="firstName"
-                name="firstName"
-                type="text"
-                placeholder="First"
-                required
-                autoComplete="given-name"
-                disabled={isPending}
-                value={firstName}
-                onChange={(e) => setFirstName(e.target.value)}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="lastName">Last name</Label>
-              <Input
-                id="lastName"
-                name="lastName"
-                type="text"
-                placeholder="Last"
-                required
-                autoComplete="family-name"
-                disabled={isPending}
-                value={lastName}
-                onChange={(e) => setLastName(e.target.value)}
-              />
-            </div>
-          </div>
-
-          {/* Email */}
-          <div className="space-y-2">
-            <Label htmlFor="email">Email address</Label>
-            <Input
-              id="email"
-              name="email"
-              type="email"
-              inputMode="email"
-              placeholder="you@example.com"
-              required
-              autoComplete="email"
-              disabled={isPending}
-              value={email}
-              onChange={(e) => {
-                setEmail(e.target.value)
-                setBlurredEmail('')
-              }}
-              onBlur={(e) => setBlurredEmail(e.target.value)}
-            />
-            <EmailTypoSuggestion
-              email={blurredEmail}
-              onAccept={(corrected) => {
-                setEmail(corrected)
-                setBlurredEmail('')
-              }}
-            />
-          </div>
-
-          {/* Cell phone */}
-          <div className="space-y-2">
-            <Label htmlFor="phone">Cell phone</Label>
-            <Input
-              id="phone"
-              name="phone"
-              type="tel"
-              inputMode="tel"
-              placeholder="Phone number"
-              required
-              autoComplete="tel"
-              disabled={isPending}
-              value={phone}
-              onChange={(e) => setPhone(e.target.value)}
-            />
-            <p className="text-xs text-muted-foreground">
-              Used only for urgent ride-day updates, such as weather or safety-related changes.
-            </p>
-          </div>
-
-          {/* Gender */}
-          <div className="space-y-2">
-            <Label htmlFor="gender">
-              Gender
-              <span className="text-muted-foreground font-normal ml-1">(optional)</span>
-            </Label>
-            <Select
-              key={gender || 'empty'}
-              value={gender}
-              onValueChange={setGender}
-              disabled={isPending}
-            >
-              <SelectTrigger id="gender" className="w-full">
-                <SelectValue placeholder="Select…" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="M">Male</SelectItem>
-                <SelectItem value="F">Female</SelectItem>
-                <SelectItem value="X">Non-binary / Other</SelectItem>
-              </SelectContent>
-            </Select>
-            <p className="text-xs text-muted-foreground">
-              Audax Club Parisien uses this for ridership statistics.
-            </p>
-          </div>
-
-          {/* Share Registration */}
-          <div className="flex items-start gap-3">
-            <Checkbox
-              checked={shareRegistration}
-              onCheckedChange={(checked) => setShareRegistration(checked === true)}
-              className="mt-1"
-              disabled={isPending}
-              aria-label="Appear on the registered riders list"
-            />
-            {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- checkbox is keyboard-accessible via aria-label */}
-            <div
-              className="space-y-1 cursor-pointer"
-              onClick={() => {
-                if (!isPending) setShareRegistration((v) => !v)
-              }}
-            >
-              <span className="text-sm font-medium leading-none">
-                Appear on the registered riders list
-              </span>
-              <p className="text-xs text-muted-foreground">
-                Allow other riders to see you're signed up. Results always include all riders.
-              </p>
-            </div>
-          </div>
-
-          {/* Emergency Contact */}
-          <div className="bg-muted/50 border border-border rounded-lg p-4 space-y-3">
-            <p className="text-sm font-medium">Emergency contact</p>
-            <div className="grid grid-cols-1 min-[400px]:grid-cols-2 gap-4">
-              <div className="space-y-2">
-                <Label htmlFor="emergencyContactName">Name</Label>
-                <Input
-                  id="emergencyContactName"
-                  name="emergencyContactName"
-                  type="text"
-                  placeholder="Name"
-                  required
-                  autoComplete="off"
-                  disabled={isPending}
-                  value={emergencyContactName}
-                  onChange={(e) => setEmergencyContactName(e.target.value)}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="emergencyContactPhone">Phone</Label>
-                <Input
-                  id="emergencyContactPhone"
-                  name="emergencyContactPhone"
-                  type="tel"
-                  inputMode="tel"
-                  placeholder="Phone number"
-                  required
-                  autoComplete="off"
-                  disabled={isPending}
-                  value={emergencyContactPhone}
-                  onChange={(e) => setEmergencyContactPhone(e.target.value)}
-                />
-              </div>
-            </div>
-          </div>
-
-          {/* Notes */}
-          <div className="space-y-2">
-            <Label htmlFor="notes">
-              Notes for the organizer
-              <span className="text-muted-foreground font-normal ml-1">(optional)</span>
-            </Label>
-            <Textarea
-              id="notes"
-              name="notes"
-              placeholder="Any special requirements or information…"
-              rows={3}
-              disabled={isPending}
-              value={notes}
-              onChange={(e) => setNotes(e.target.value)}
-            />
-          </div>
+          <RiderInfoFields form={form} />
+          <ShareRegistrationCheckbox form={form} />
+          <EmergencyContactFields form={form} />
+          <NotesField disabled={isPending} value={notes} onChange={setNotes} />
         </div>
 
         {/* Submit */}
@@ -664,22 +341,7 @@ export function PermanentRegistrationForm({ routes }: PermanentRegistrationFormP
         </Button>
       </form>
 
-      <RiderMatchDialog
-        open={matchDialogOpen}
-        onOpenChange={setMatchDialogOpen}
-        candidates={matchCandidates}
-        submittedFirstName={firstName}
-        submittedLastName={lastName}
-        onSelectRider={(riderId) => handleRiderSelection(riderId)}
-        onCreateNew={() => handleRiderSelection(null)}
-        isPending={isPending}
-      />
-
-      <MembershipErrorModal
-        open={membershipErrorVariant !== null}
-        onClose={() => setMembershipErrorVariant(null)}
-        variant={membershipErrorVariant || 'no-membership'}
-      />
+      <RegistrationDialogs form={form} onSelectRider={handleRiderSelection} />
     </div>
   )
 }

--- a/components/registration-form.tsx
+++ b/components/registration-form.tsx
@@ -1,30 +1,24 @@
 'use client'
 
-import { useState, useTransition, useEffect, useRef } from 'react'
-import { useRouter } from 'next/navigation'
+import { useState } from 'react'
 import Link from 'next/link'
-import { Input } from '@/components/ui/input'
-import { Textarea } from '@/components/ui/textarea'
-import { Label } from '@/components/ui/label'
-import { Checkbox } from '@/components/ui/checkbox'
 import { Button } from '@/components/ui/button'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
 import { registerForEvent, completeRegistrationWithRider } from '@/lib/actions/register'
-import { RiderMatchDialog } from '@/components/rider-match-dialog'
-import type { RiderMatchCandidate } from '@/lib/actions/rider-match'
-import { getUpcomingEventsByEventId, type UpcomingEvent } from '@/lib/actions/rider-results'
-import { format } from 'date-fns'
-import { ArrowRight } from 'lucide-react'
-import { MembershipErrorModal } from '@/components/membership-error-modal'
 import { HoneypotField } from '@/components/honeypot-field'
-import { EmailTypoSuggestion } from '@/components/email-typo-suggestion'
-import { getSavedRegistrationData, saveRegistrationData } from '@/lib/registration-storage'
+import { useRegistrationForm } from '@/hooks/use-registration-form'
+import {
+  RegistrationError,
+  RiderInfoFields,
+  EmergencyContactFields,
+  ShareRegistrationCheckbox,
+  NotesField,
+} from '@/components/registration/registration-fields'
+import {
+  RegistrationSuccess,
+  UpcomingEventsLoading,
+  UpcomingEventsSection,
+} from '@/components/registration/registration-success'
+import { RegistrationDialogs } from '@/components/registration/registration-dialogs'
 
 interface RegistrationFormProps {
   eventId: string
@@ -38,70 +32,15 @@ export function RegistrationForm({
   isPermanent,
   variant = 'card',
 }: RegistrationFormProps) {
-  const router = useRouter()
-  const [isPending, startTransition] = useTransition()
-  const [firstName, setFirstName] = useState('')
-  const [lastName, setLastName] = useState('')
-  const [email, setEmail] = useState('')
-  const [blurredEmail, setBlurredEmail] = useState('')
-  const [phone, setPhone] = useState('')
-  const [shareRegistration, setShareRegistration] = useState(true)
-  const [gender, setGender] = useState<string>('')
-  const [emergencyContactName, setEmergencyContactName] = useState('')
-  const [emergencyContactPhone, setEmergencyContactPhone] = useState('')
-  const [homepageUrl, setHomepageUrl] = useState('')
-  const [error, setError] = useState<string | null>(null)
-  const [success, setSuccess] = useState(false)
-
-  // Membership error state
-  const [membershipErrorVariant, setMembershipErrorVariant] = useState<
-    'no-membership' | 'trial-used' | null
-  >(null)
-
-  // Fuzzy matching state
-  const [matchDialogOpen, setMatchDialogOpen] = useState(false)
-  const [matchCandidates, setMatchCandidates] = useState<RiderMatchCandidate[]>([])
-  const [pendingNotes, setPendingNotes] = useState<string>('')
-
-  // Upcoming events state
-  const [upcomingEvents, setUpcomingEvents] = useState<UpcomingEvent[]>([])
-  const [loadingEvents, setLoadingEvents] = useState(false)
-
-  const errorRef = useRef<HTMLDivElement>(null)
-  const successRef = useRef<HTMLDivElement>(null)
-
-  // Load saved data on mount
-  useEffect(() => {
-    const saved = getSavedRegistrationData()
-    if (saved) {
-      setFirstName(saved.firstName)
-      setLastName(saved.lastName)
-      setEmail(saved.email)
-      setPhone(saved.phone || '')
-      setGender(saved.gender)
-      setShareRegistration(saved.shareRegistration)
-      setEmergencyContactName(saved.emergencyContactName || '')
-      setEmergencyContactPhone(saved.emergencyContactPhone || '')
-    }
-  }, [])
-
-  // Scroll error into view when it appears
-  useEffect(() => {
-    if (error && errorRef.current) {
-      errorRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
-    }
-  }, [error])
-
-  // Move focus to success message when registration completes
-  useEffect(() => {
-    if (success && successRef.current) {
-      successRef.current.focus()
-    }
-  }, [success])
+  const form = useRegistrationForm({
+    upcomingEventsEventId: isPermanent ? undefined : eventId,
+  })
+  const { isPending, startTransition } = form
+  const [pendingNotes, setPendingNotes] = useState('')
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
-    setError(null)
+    form.setError(null)
 
     const formData = new FormData(e.currentTarget)
     const notes = formData.get('notes') as string
@@ -109,117 +48,24 @@ export function RegistrationForm({
     startTransition(async () => {
       const result = await registerForEvent({
         eventId,
-        firstName,
-        lastName,
-        email,
-        phone,
-        gender: gender || undefined,
-        shareRegistration,
+        ...form.riderPayload,
         notes: notes || undefined,
-        emergencyContactName,
-        emergencyContactPhone,
-        homepageUrl,
       })
-
-      if (result.success) {
-        // Save form data to localStorage for next registration
-        saveRegistrationData({
-          firstName,
-          lastName,
-          email,
-          phone,
-          gender,
-          shareRegistration,
-          emergencyContactName,
-          emergencyContactPhone,
-        })
-        setSuccess(true)
-        router.refresh()
-
-        // Fetch upcoming events for non-permanents
-        if (!isPermanent) {
-          setLoadingEvents(true)
-          getUpcomingEventsByEventId(eventId, 3)
-            .then((eventsResult) => {
-              if (eventsResult.success && eventsResult.data) {
-                setUpcomingEvents(eventsResult.data)
-              }
-            })
-            .catch(() => {
-              // Silently fail - the events are a nice-to-have
-            })
-            .finally(() => {
-              setLoadingEvents(false)
-            })
-        }
-      } else if (result.needsRiderMatch && result.matchCandidates) {
-        // Show fuzzy matching dialog
-        setMatchCandidates(result.matchCandidates)
-        setPendingNotes(notes || '')
-        setMatchDialogOpen(true)
-      } else if (result.membershipError) {
-        setMembershipErrorVariant(result.membershipError)
-      } else {
-        setError(result.error || 'Registration failed')
-      }
+      form.handleRegistrationResult(result, {
+        onNeedsMatch: () => setPendingNotes(notes || ''),
+      })
     })
   }
 
-  async function handleRiderSelection(riderId: string | null) {
+  function handleRiderSelection(riderId: string | null) {
     startTransition(async () => {
       const result = await completeRegistrationWithRider({
         eventId,
         selectedRiderId: riderId,
-        firstName,
-        lastName,
-        email,
-        phone,
-        gender: gender || undefined,
-        shareRegistration,
+        ...form.riderPayload,
         notes: pendingNotes || undefined,
-        emergencyContactName,
-        emergencyContactPhone,
-        homepageUrl,
       })
-
-      if (result.success) {
-        setMatchDialogOpen(false)
-        saveRegistrationData({
-          firstName,
-          lastName,
-          email,
-          phone,
-          gender,
-          shareRegistration,
-          emergencyContactName,
-          emergencyContactPhone,
-        })
-        setSuccess(true)
-        router.refresh()
-
-        // Fetch upcoming events for non-permanents
-        if (!isPermanent) {
-          setLoadingEvents(true)
-          getUpcomingEventsByEventId(eventId, 3)
-            .then((eventsResult) => {
-              if (eventsResult.success && eventsResult.data) {
-                setUpcomingEvents(eventsResult.data)
-              }
-            })
-            .catch(() => {
-              // Silently fail - the events are a nice-to-have
-            })
-            .finally(() => {
-              setLoadingEvents(false)
-            })
-        }
-      } else if (result.membershipError) {
-        setMatchDialogOpen(false)
-        setMembershipErrorVariant(result.membershipError)
-      } else {
-        setMatchDialogOpen(false)
-        setError(result.error || 'Registration failed')
-      }
+      form.handleRegistrationResult(result)
     })
   }
 
@@ -228,54 +74,17 @@ export function RegistrationForm({
       ? 'lg:sticky lg:top-24 rounded-2xl border border-border bg-card p-6 md:p-8'
       : undefined
 
-  if (success) {
+  if (form.success) {
     return (
       <div className={wrapperClassName}>
-        <div
-          ref={successRef}
-          tabIndex={-1}
-          role="status"
-          className="text-center py-8"
-          data-testid="registration-success"
-        >
-          <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-green-100 dark:bg-green-900/30 mb-4">
-            <svg
-              className="w-6 h-6 text-green-600 dark:text-green-400"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M5 13l4 4L19 7"
-              />
-            </svg>
-          </div>
-          <h2 className="font-serif text-2xl tracking-tight mb-2">You're registered!</h2>
-          <p className="text-sm text-muted-foreground">See you at the start line.</p>
-        </div>
+        <RegistrationSuccess successRef={form.successRef} title="You're registered!">
+          See you at the start line.
+        </RegistrationSuccess>
 
-        {/* Upcoming Events Section */}
-        {loadingEvents && (
-          <div className="border-t border-border pt-6 mt-6">
-            <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
-              <div className="w-4 h-4 border-2 border-muted-foreground border-t-transparent rounded-full animate-spin" />
-              Loading upcoming events…
-            </div>
-          </div>
-        )}
+        {form.loadingEvents && <UpcomingEventsLoading />}
 
-        {!loadingEvents && upcomingEvents.length > 0 && (
-          <div className="border-t border-border pt-6 mt-6">
-            <h3 className="font-medium text-sm mb-4 text-center">More Upcoming Events</h3>
-            <div className="space-y-3">
-              {upcomingEvents.map((event) => (
-                <UpcomingEventCard key={event.id} event={event} />
-              ))}
-            </div>
-          </div>
+        {!form.loadingEvents && form.upcomingEvents.length > 0 && (
+          <UpcomingEventsSection title="More Upcoming Events" events={form.upcomingEvents} />
         )}
       </div>
     )
@@ -302,201 +111,13 @@ export function RegistrationForm({
       )}
 
       <form className="space-y-5" onSubmit={handleSubmit}>
-        <HoneypotField value={homepageUrl} onChange={setHomepageUrl} />
-        {error && (
-          <div
-            ref={errorRef}
-            role="alert"
-            className="p-3 rounded-lg bg-destructive/10 text-destructive text-sm"
-            data-testid="registration-error"
-          >
-            {error}
-          </div>
-        )}
+        <HoneypotField value={form.homepageUrl} onChange={form.setHomepageUrl} />
+        <RegistrationError form={form} />
+        <RiderInfoFields form={form} />
+        <EmergencyContactFields form={form} />
+        <NotesField disabled={isPending} />
+        <ShareRegistrationCheckbox form={form} />
 
-        {/* Name */}
-        <div className="grid grid-cols-1 min-[400px]:grid-cols-2 gap-4">
-          <div className="space-y-2">
-            <Label htmlFor="firstName">First name</Label>
-            <Input
-              id="firstName"
-              name="firstName"
-              type="text"
-              placeholder="First"
-              required
-              autoComplete="given-name"
-              disabled={isPending}
-              value={firstName}
-              onChange={(e) => setFirstName(e.target.value)}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="lastName">Last name</Label>
-            <Input
-              id="lastName"
-              name="lastName"
-              type="text"
-              placeholder="Last"
-              required
-              autoComplete="family-name"
-              disabled={isPending}
-              value={lastName}
-              onChange={(e) => setLastName(e.target.value)}
-            />
-          </div>
-        </div>
-
-        {/* Email */}
-        <div className="space-y-2">
-          <Label htmlFor="email">Email address</Label>
-          <Input
-            id="email"
-            name="email"
-            type="email"
-            inputMode="email"
-            placeholder="you@example.com"
-            required
-            autoComplete="email"
-            disabled={isPending}
-            value={email}
-            onChange={(e) => {
-              setEmail(e.target.value)
-              setBlurredEmail('')
-            }}
-            onBlur={(e) => setBlurredEmail(e.target.value)}
-          />
-          <EmailTypoSuggestion
-            email={blurredEmail}
-            onAccept={(corrected) => {
-              setEmail(corrected)
-              setBlurredEmail('')
-            }}
-          />
-        </div>
-
-        {/* Cell phone */}
-        <div className="space-y-2">
-          <Label htmlFor="phone">Cell phone</Label>
-          <Input
-            id="phone"
-            name="phone"
-            type="tel"
-            inputMode="tel"
-            placeholder="Phone number"
-            required
-            autoComplete="tel"
-            disabled={isPending}
-            value={phone}
-            onChange={(e) => setPhone(e.target.value)}
-          />
-          <p className="text-xs text-muted-foreground">
-            Used only for urgent ride-day updates, such as weather or safety-related changes.
-          </p>
-        </div>
-
-        {/* Gender */}
-        <div className="space-y-2">
-          <Label htmlFor="gender">
-            Gender
-            <span className="text-muted-foreground font-normal ml-1">(optional)</span>
-          </Label>
-          <Select
-            key={gender || 'empty'}
-            value={gender}
-            onValueChange={setGender}
-            disabled={isPending}
-          >
-            <SelectTrigger id="gender" className="w-full">
-              <SelectValue placeholder="Select…" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="M">Male</SelectItem>
-              <SelectItem value="F">Female</SelectItem>
-              <SelectItem value="X">Non-binary / Other</SelectItem>
-            </SelectContent>
-          </Select>
-          <p className="text-xs text-muted-foreground">
-            Audax Club Parisien uses this for ridership statistics.
-          </p>
-        </div>
-
-        {/* Emergency Contact */}
-        <div className="bg-muted/50 border border-border rounded-lg p-4 space-y-3">
-          <p className="text-sm font-medium">Emergency contact</p>
-          <div className="grid grid-cols-1 min-[400px]:grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label htmlFor="emergencyContactName">Name</Label>
-              <Input
-                id="emergencyContactName"
-                name="emergencyContactName"
-                type="text"
-                placeholder="Name"
-                required
-                autoComplete="off"
-                disabled={isPending}
-                value={emergencyContactName}
-                onChange={(e) => setEmergencyContactName(e.target.value)}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="emergencyContactPhone">Phone</Label>
-              <Input
-                id="emergencyContactPhone"
-                name="emergencyContactPhone"
-                type="tel"
-                inputMode="tel"
-                placeholder="Phone number"
-                required
-                autoComplete="off"
-                disabled={isPending}
-                value={emergencyContactPhone}
-                onChange={(e) => setEmergencyContactPhone(e.target.value)}
-              />
-            </div>
-          </div>
-        </div>
-
-        {/* Notes */}
-        <div className="space-y-2">
-          <Label htmlFor="notes">
-            Notes for the organizer
-            <span className="text-muted-foreground font-normal ml-1">(optional)</span>
-          </Label>
-          <Textarea
-            id="notes"
-            name="notes"
-            placeholder="Any special requirements or information…"
-            rows={3}
-            disabled={isPending}
-          />
-        </div>
-
-        {/* Share Registration */}
-        <div className="flex items-start gap-3">
-          <Checkbox
-            checked={shareRegistration}
-            onCheckedChange={(checked) => setShareRegistration(checked === true)}
-            className="mt-1"
-            disabled={isPending}
-            aria-label="Appear on the registered riders list"
-          />
-          {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- checkbox is keyboard-accessible via aria-label */}
-          <div
-            className="space-y-1 cursor-pointer"
-            onClick={() => {
-              if (!isPending) setShareRegistration((v) => !v)
-            }}
-          >
-            <span className="text-sm font-medium leading-none">
-              Appear on the registered riders list
-            </span>
-            <p className="text-xs text-muted-foreground">
-              Allow other riders to see you're signed up. Results always include all riders.
-            </p>
-          </div>
-        </div>
-
-        {/* Submit */}
         <Button
           type="submit"
           className="w-full h-12"
@@ -508,55 +129,7 @@ export function RegistrationForm({
         </Button>
       </form>
 
-      <RiderMatchDialog
-        open={matchDialogOpen}
-        onOpenChange={setMatchDialogOpen}
-        candidates={matchCandidates}
-        submittedFirstName={firstName}
-        submittedLastName={lastName}
-        onSelectRider={(riderId) => handleRiderSelection(riderId)}
-        onCreateNew={() => handleRiderSelection(null)}
-        isPending={isPending}
-      />
-
-      <MembershipErrorModal
-        open={membershipErrorVariant !== null}
-        onClose={() => setMembershipErrorVariant(null)}
-        variant={membershipErrorVariant || 'no-membership'}
-      />
-    </div>
-  )
-}
-
-interface UpcomingEventCardProps {
-  event: UpcomingEvent
-}
-
-function UpcomingEventCard({ event }: UpcomingEventCardProps) {
-  return (
-    <div className="flex items-center gap-4 p-3 rounded-lg border border-border bg-muted/30">
-      <div className="flex-shrink-0 text-center w-14">
-        <div className="text-xs text-muted-foreground uppercase">
-          {format(new Date(event.date + 'T00:00:00'), 'MMM')}
-        </div>
-        <div className="text-lg font-medium tabular-nums">
-          {format(new Date(event.date + 'T00:00:00'), 'd')}
-        </div>
-      </div>
-      <div className="flex-1 min-w-0">
-        <div className="font-medium text-sm truncate">{event.name}</div>
-        <div className="text-xs text-muted-foreground mt-0.5 tabular-nums">{event.distance} km</div>
-        {event.startLocation && (
-          <div className="text-xs text-muted-foreground truncate">{event.startLocation}</div>
-        )}
-      </div>
-      <Link
-        href={`/register/${event.slug}`}
-        className="flex-shrink-0 inline-flex items-center gap-1 text-sm text-primary hover:underline"
-      >
-        Register
-        <ArrowRight className="h-3.5 w-3.5" />
-      </Link>
+      <RegistrationDialogs form={form} onSelectRider={handleRiderSelection} />
     </div>
   )
 }

--- a/components/registration-form.tsx
+++ b/components/registration-form.tsx
@@ -24,37 +24,7 @@ import { ArrowRight } from 'lucide-react'
 import { MembershipErrorModal } from '@/components/membership-error-modal'
 import { HoneypotField } from '@/components/honeypot-field'
 import { EmailTypoSuggestion } from '@/components/email-typo-suggestion'
-
-const STORAGE_KEY = 'ro-registration'
-
-interface SavedRegistrationData {
-  firstName: string
-  lastName: string
-  email: string
-  phone: string
-  gender: string
-  shareRegistration: boolean
-  emergencyContactName: string
-  emergencyContactPhone: string
-}
-
-function getSavedData(): SavedRegistrationData | null {
-  if (typeof window === 'undefined') return null
-  try {
-    const saved = localStorage.getItem(STORAGE_KEY)
-    return saved ? JSON.parse(saved) : null
-  } catch {
-    return null
-  }
-}
-
-function saveData(data: SavedRegistrationData): void {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
-  } catch {
-    // Ignore storage errors
-  }
-}
+import { getSavedRegistrationData, saveRegistrationData } from '@/lib/registration-storage'
 
 interface RegistrationFormProps {
   eventId: string
@@ -102,7 +72,7 @@ export function RegistrationForm({
 
   // Load saved data on mount
   useEffect(() => {
-    const saved = getSavedData()
+    const saved = getSavedRegistrationData()
     if (saved) {
       setFirstName(saved.firstName)
       setLastName(saved.lastName)
@@ -153,7 +123,7 @@ export function RegistrationForm({
 
       if (result.success) {
         // Save form data to localStorage for next registration
-        saveData({
+        saveRegistrationData({
           firstName,
           lastName,
           email,
@@ -214,7 +184,7 @@ export function RegistrationForm({
 
       if (result.success) {
         setMatchDialogOpen(false)
-        saveData({
+        saveRegistrationData({
           firstName,
           lastName,
           email,

--- a/components/registration/registration-dialogs.tsx
+++ b/components/registration/registration-dialogs.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { RiderMatchDialog } from '@/components/rider-match-dialog'
+import { MembershipErrorModal } from '@/components/membership-error-modal'
+import type { RegistrationFormState } from '@/hooks/use-registration-form'
+
+interface RegistrationDialogsProps {
+  form: RegistrationFormState
+  /** Called with the chosen rider id, or null to create a new rider. */
+  onSelectRider: (riderId: string | null) => void
+}
+
+/** Fuzzy rider-match dialog + membership error modal, wired to the shared form state. */
+export function RegistrationDialogs({ form, onSelectRider }: RegistrationDialogsProps) {
+  return (
+    <>
+      <RiderMatchDialog
+        open={form.matchDialogOpen}
+        onOpenChange={form.setMatchDialogOpen}
+        candidates={form.matchCandidates}
+        submittedFirstName={form.firstName}
+        submittedLastName={form.lastName}
+        onSelectRider={onSelectRider}
+        onCreateNew={() => onSelectRider(null)}
+        isPending={form.isPending}
+      />
+      <MembershipErrorModal
+        open={form.membershipErrorVariant !== null}
+        onClose={() => form.setMembershipErrorVariant(null)}
+        variant={form.membershipErrorVariant || 'no-membership'}
+      />
+    </>
+  )
+}

--- a/components/registration/registration-fields.tsx
+++ b/components/registration/registration-fields.tsx
@@ -1,0 +1,251 @@
+'use client'
+
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Label } from '@/components/ui/label'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { EmailTypoSuggestion } from '@/components/email-typo-suggestion'
+import type { RegistrationFormState } from '@/hooks/use-registration-form'
+
+interface FormSectionProps {
+  form: RegistrationFormState
+}
+
+/** Inline error banner shown above the form fields. */
+export function RegistrationError({ form }: FormSectionProps) {
+  // Destructured before use: the react-hooks/refs lint rule flags direct
+  // `form.errorRef` / `form.error` member access in JSX as a ref read during
+  // render (a false positive here — `form` mixes a ref with plain state).
+  const { errorRef, error } = form
+  if (!error) return null
+  return (
+    <div
+      ref={errorRef}
+      role="alert"
+      className="p-3 rounded-lg bg-destructive/10 text-destructive text-sm"
+      data-testid="registration-error"
+    >
+      {error}
+    </div>
+  )
+}
+
+/** Name grid, email (with typo suggestion), cell phone, and gender select. */
+export function RiderInfoFields({ form }: FormSectionProps) {
+  const { isPending } = form
+  return (
+    <>
+      {/* Name */}
+      <div className="grid grid-cols-1 min-[400px]:grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor="firstName">First name</Label>
+          <Input
+            id="firstName"
+            name="firstName"
+            type="text"
+            placeholder="First"
+            required
+            autoComplete="given-name"
+            disabled={isPending}
+            value={form.firstName}
+            onChange={(e) => form.setFirstName(e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="lastName">Last name</Label>
+          <Input
+            id="lastName"
+            name="lastName"
+            type="text"
+            placeholder="Last"
+            required
+            autoComplete="family-name"
+            disabled={isPending}
+            value={form.lastName}
+            onChange={(e) => form.setLastName(e.target.value)}
+          />
+        </div>
+      </div>
+
+      {/* Email */}
+      <div className="space-y-2">
+        <Label htmlFor="email">Email address</Label>
+        <Input
+          id="email"
+          name="email"
+          type="email"
+          inputMode="email"
+          placeholder="you@example.com"
+          required
+          autoComplete="email"
+          disabled={isPending}
+          value={form.email}
+          onChange={(e) => {
+            form.setEmail(e.target.value)
+            form.setBlurredEmail('')
+          }}
+          onBlur={(e) => form.setBlurredEmail(e.target.value)}
+        />
+        <EmailTypoSuggestion
+          email={form.blurredEmail}
+          onAccept={(corrected) => {
+            form.setEmail(corrected)
+            form.setBlurredEmail('')
+          }}
+        />
+      </div>
+
+      {/* Cell phone */}
+      <div className="space-y-2">
+        <Label htmlFor="phone">Cell phone</Label>
+        <Input
+          id="phone"
+          name="phone"
+          type="tel"
+          inputMode="tel"
+          placeholder="Phone number"
+          required
+          autoComplete="tel"
+          disabled={isPending}
+          value={form.phone}
+          onChange={(e) => form.setPhone(e.target.value)}
+        />
+        <p className="text-xs text-muted-foreground">
+          Used only for urgent ride-day updates, such as weather or safety-related changes.
+        </p>
+      </div>
+
+      {/* Gender */}
+      <div className="space-y-2">
+        <Label htmlFor="gender">
+          Gender
+          <span className="text-muted-foreground font-normal ml-1">(optional)</span>
+        </Label>
+        <Select
+          key={form.gender || 'empty'}
+          value={form.gender}
+          onValueChange={form.setGender}
+          disabled={isPending}
+        >
+          <SelectTrigger id="gender" className="w-full">
+            <SelectValue placeholder="Select…" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="M">Male</SelectItem>
+            <SelectItem value="F">Female</SelectItem>
+            <SelectItem value="X">Non-binary / Other</SelectItem>
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          Audax Club Parisien uses this for ridership statistics.
+        </p>
+      </div>
+    </>
+  )
+}
+
+/** Emergency contact name/phone in a highlighted fieldset. */
+export function EmergencyContactFields({ form }: FormSectionProps) {
+  const { isPending } = form
+  return (
+    <fieldset className="bg-muted/50 border border-border rounded-lg p-4 space-y-3">
+      <legend className="text-sm font-medium">Emergency contact</legend>
+      <div className="grid grid-cols-1 min-[400px]:grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor="emergencyContactName">Name</Label>
+          <Input
+            id="emergencyContactName"
+            name="emergencyContactName"
+            type="text"
+            placeholder="Name"
+            required
+            autoComplete="off"
+            disabled={isPending}
+            value={form.emergencyContactName}
+            onChange={(e) => form.setEmergencyContactName(e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="emergencyContactPhone">Phone</Label>
+          <Input
+            id="emergencyContactPhone"
+            name="emergencyContactPhone"
+            type="tel"
+            inputMode="tel"
+            placeholder="Phone number"
+            required
+            autoComplete="off"
+            disabled={isPending}
+            value={form.emergencyContactPhone}
+            onChange={(e) => form.setEmergencyContactPhone(e.target.value)}
+          />
+        </div>
+      </div>
+    </fieldset>
+  )
+}
+
+/** "Appear on the registered riders list" checkbox with clickable label. */
+export function ShareRegistrationCheckbox({ form }: FormSectionProps) {
+  const { isPending } = form
+  return (
+    <div className="flex items-start gap-3">
+      <Checkbox
+        checked={form.shareRegistration}
+        onCheckedChange={(checked) => form.setShareRegistration(checked === true)}
+        className="mt-1"
+        disabled={isPending}
+        aria-label="Appear on the registered riders list"
+      />
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- checkbox is keyboard-accessible via aria-label */}
+      <div
+        className="space-y-1 cursor-pointer"
+        onClick={() => {
+          if (!isPending) form.setShareRegistration(!form.shareRegistration)
+        }}
+      >
+        <span className="text-sm font-medium leading-none">
+          Appear on the registered riders list
+        </span>
+        <p className="text-xs text-muted-foreground">
+          Allow other riders to see you&apos;re signed up. Results always include all riders.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+interface NotesFieldProps {
+  disabled: boolean
+  /** Controlled usage (permanent form); omit both to read via FormData on submit. */
+  value?: string
+  onChange?: (value: string) => void
+}
+
+/** "Notes for the organizer" textarea. */
+export function NotesField({ disabled, value, onChange }: NotesFieldProps) {
+  return (
+    <div className="space-y-2">
+      <Label htmlFor="notes">
+        Notes for the organizer
+        <span className="text-muted-foreground font-normal ml-1">(optional)</span>
+      </Label>
+      <Textarea
+        id="notes"
+        name="notes"
+        placeholder="Any special requirements or information…"
+        rows={3}
+        disabled={disabled}
+        value={value}
+        onChange={onChange ? (e) => onChange(e.target.value) : undefined}
+      />
+    </div>
+  )
+}

--- a/components/registration/registration-success.tsx
+++ b/components/registration/registration-success.tsx
@@ -1,0 +1,123 @@
+'use client'
+
+import Link from 'next/link'
+import { format } from 'date-fns'
+import { ArrowRight } from 'lucide-react'
+import type { UpcomingEvent } from '@/lib/actions/rider-results'
+
+interface RegistrationSuccessProps {
+  title: string
+  children: React.ReactNode
+  /** Forms pass their focus ref so the success message receives focus. */
+  successRef?: React.RefObject<HTMLDivElement | null>
+}
+
+/** Green-checkmark success block shared by the registration and result forms. */
+export function RegistrationSuccess({ title, children, successRef }: RegistrationSuccessProps) {
+  return (
+    <div
+      ref={successRef}
+      tabIndex={successRef ? -1 : undefined}
+      role="status"
+      className="text-center py-8"
+      data-testid="registration-success"
+    >
+      <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-green-100 dark:bg-green-900/30 mb-4">
+        <svg
+          aria-hidden="true"
+          className="w-6 h-6 text-green-600 dark:text-green-400"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+        </svg>
+      </div>
+      <h2 className="font-serif text-2xl tracking-tight mb-2">{title}</h2>
+      <p className="text-sm text-muted-foreground">{children}</p>
+    </div>
+  )
+}
+
+/** Spinner row shown while upcoming events load below the success block. */
+export function UpcomingEventsLoading() {
+  return (
+    <div className="border-t border-border pt-6 mt-6" role="status">
+      <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
+        <div
+          className="w-4 h-4 border-2 border-muted-foreground border-t-transparent rounded-full animate-spin"
+          aria-hidden="true"
+        />
+        Loading upcoming events…
+      </div>
+    </div>
+  )
+}
+
+interface UpcomingEventsSectionProps {
+  title: string
+  description?: string
+  events: UpcomingEvent[]
+  /** True when the rider is already registered for these events ("Details" link). */
+  isRegistered?: boolean
+}
+
+/** Titled list of upcoming-event cards below the success block. */
+export function UpcomingEventsSection({
+  title,
+  description,
+  events,
+  isRegistered = false,
+}: UpcomingEventsSectionProps) {
+  return (
+    <div className="border-t border-border pt-6 mt-6">
+      <h3 className={`font-medium text-sm text-center ${description ? 'mb-1' : 'mb-4'}`}>
+        {title}
+      </h3>
+      {description && (
+        <p className="text-xs text-muted-foreground mb-4 text-center">{description}</p>
+      )}
+      <div className="space-y-3">
+        {events.map((event) => (
+          <UpcomingEventCard key={event.id} event={event} isRegistered={isRegistered} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+interface UpcomingEventCardProps {
+  event: UpcomingEvent
+  isRegistered?: boolean
+}
+
+export function UpcomingEventCard({ event, isRegistered = false }: UpcomingEventCardProps) {
+  const label = isRegistered ? 'Details' : 'Register'
+  return (
+    <div className="flex items-center gap-4 p-3 rounded-lg border border-border bg-muted/30">
+      <div className="flex-shrink-0 text-center w-14">
+        <div className="text-xs text-muted-foreground uppercase">
+          {format(new Date(event.date + 'T00:00:00'), 'MMM')}
+        </div>
+        <div className="text-lg font-medium tabular-nums">
+          {format(new Date(event.date + 'T00:00:00'), 'd')}
+        </div>
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="font-medium text-sm truncate">{event.name}</div>
+        <div className="text-xs text-muted-foreground mt-0.5 tabular-nums">{event.distance} km</div>
+        {event.startLocation && (
+          <div className="text-xs text-muted-foreground truncate">{event.startLocation}</div>
+        )}
+      </div>
+      <Link
+        href={`/register/${event.slug}`}
+        className="flex-shrink-0 inline-flex items-center gap-1 text-sm text-primary hover:underline"
+        aria-label={`${label === 'Details' ? 'Details for' : 'Register for'} ${event.name}`}
+      >
+        {label}
+        <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+      </Link>
+    </div>
+  )
+}

--- a/components/result-submission-form.tsx
+++ b/components/result-submission-form.tsx
@@ -25,18 +25,8 @@ import {
 } from '@/lib/actions/rider-results'
 import { createClient as createSupabaseBrowserClient } from '@/lib/supabase-browser'
 import { compressImageForUpload } from '@/lib/image-compression'
-import {
-  Upload,
-  X,
-  FileText,
-  Image as ImageIcon,
-  ExternalLink,
-  Clock,
-  ArrowRight,
-  Route,
-} from 'lucide-react'
+import { Upload, X, FileText, Image as ImageIcon, ExternalLink, Clock, Route } from 'lucide-react'
 import { format } from 'date-fns'
-import Link from 'next/link'
 import {
   calculateElapsedMinutes,
   formatElapsedForDisplay,
@@ -44,6 +34,11 @@ import {
   getAcpTimeLimitMinutes,
   getFinishDayOptions,
 } from '@/lib/events/finish-time'
+import {
+  RegistrationSuccess,
+  UpcomingEventsLoading,
+  UpcomingEventsSection,
+} from '@/components/registration/registration-success'
 
 interface ResultSubmissionFormProps {
   token: string
@@ -340,63 +335,28 @@ export function ResultSubmissionForm({ token, initialData }: ResultSubmissionFor
   if (success) {
     return (
       <div className="rounded-2xl border border-border bg-card p-6 md:p-8">
-        <div className="text-center py-8">
-          <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-green-100 dark:bg-green-900/30 mb-4">
-            <svg
-              className="w-6 h-6 text-green-600 dark:text-green-400"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M5 13l4 4L19 7"
-              />
-            </svg>
-          </div>
-          <h2 className="font-serif text-2xl tracking-tight mb-2">Result Submitted!</h2>
-          <p className="text-sm text-muted-foreground">
-            Thank you for submitting your result.
-            <br />
-            Your chapter VP will review and submit to ACP.
-          </p>
-        </div>
+        <RegistrationSuccess title="Result Submitted!">
+          Thank you for submitting your result.
+          <br />
+          Your chapter VP will review and submit to ACP.
+        </RegistrationSuccess>
 
-        {/* Upcoming Events Section */}
-        {loadingEvents && (
-          <div className="border-t border-border pt-6 mt-6">
-            <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
-              <div className="w-4 h-4 border-2 border-muted-foreground border-t-transparent rounded-full animate-spin" />
-              Loading upcoming events…
-            </div>
-          </div>
-        )}
+        {loadingEvents && <UpcomingEventsLoading />}
 
         {!loadingEvents && upcomingEvents.length > 0 && (
-          <div className="border-t border-border pt-6 mt-6">
-            <h3 className="font-medium text-sm mb-4 text-center">Your Upcoming Events</h3>
-            <div className="space-y-3">
-              {upcomingEvents.map((event) => (
-                <UpcomingEventCard key={event.id} event={event} isRegistered={true} />
-              ))}
-            </div>
-          </div>
+          <UpcomingEventsSection
+            title="Your Upcoming Events"
+            events={upcomingEvents}
+            isRegistered
+          />
         )}
 
         {!loadingEvents && upcomingEvents.length === 0 && suggestedEvents.length > 0 && (
-          <div className="border-t border-border pt-6 mt-6">
-            <h3 className="font-medium text-sm mb-1 text-center">Ready for Your Next Ride?</h3>
-            <p className="text-xs text-muted-foreground mb-4 text-center">
-              Here are some upcoming events in {initialData.chapterName}
-            </p>
-            <div className="space-y-3">
-              {suggestedEvents.map((event) => (
-                <UpcomingEventCard key={event.id} event={event} isRegistered={false} />
-              ))}
-            </div>
-          </div>
+          <UpcomingEventsSection
+            title="Ready for Your Next Ride?"
+            description={`Here are some upcoming events in ${initialData.chapterName}`}
+            events={suggestedEvents}
+          />
         )}
       </div>
     )
@@ -864,11 +824,6 @@ function FileUploadField({
   )
 }
 
-interface UpcomingEventCardProps {
-  event: UpcomingEvent
-  isRegistered: boolean
-}
-
 interface DecodedInitialFinish {
   clockTime: string
   dayOffset: number
@@ -907,33 +862,4 @@ function decodeInitialFinish(
   const cm = minOnDay % 60
   const clockTime = `${String(ch).padStart(2, '0')}:${String(cm).padStart(2, '0')}`
   return { clockTime, dayOffset, elapsedHours, elapsedMinutes }
-}
-
-function UpcomingEventCard({ event, isRegistered }: UpcomingEventCardProps) {
-  return (
-    <div className="flex items-center gap-4 p-3 rounded-lg border border-border bg-muted/30">
-      <div className="flex-shrink-0 text-center w-14">
-        <div className="text-xs text-muted-foreground uppercase">
-          {format(new Date(event.date + 'T00:00:00'), 'MMM')}
-        </div>
-        <div className="text-lg font-medium tabular-nums">
-          {format(new Date(event.date + 'T00:00:00'), 'd')}
-        </div>
-      </div>
-      <div className="flex-1 min-w-0">
-        <div className="font-medium text-sm truncate">{event.name}</div>
-        <div className="text-xs text-muted-foreground mt-0.5 tabular-nums">{event.distance} km</div>
-        {event.startLocation && (
-          <div className="text-xs text-muted-foreground truncate">{event.startLocation}</div>
-        )}
-      </div>
-      <Link
-        href={`/register/${event.slug}`}
-        className="flex-shrink-0 inline-flex items-center gap-1 text-sm text-primary hover:underline"
-      >
-        {isRegistered ? 'Details' : 'Register'}
-        <ArrowRight className="h-3.5 w-3.5" />
-      </Link>
-    </div>
-  )
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -43,6 +43,7 @@ randonneurs-ontario/
 │
 ├── components/               # React components
 │   ├── admin/                # Admin-specific components
+│   ├── registration/         # Shared registration form building blocks (docs/registration-forms.md)
 │   ├── ui/                   # shadcn/ui primitive components
 │   └── *.tsx                 # Page-level components
 │
@@ -52,6 +53,7 @@ randonneurs-ontario/
 │   ├── email/                # Email templates and sending
 │   ├── auth/                 # Authentication utilities
 │   ├── supabase*.ts          # Database client configurations
+│   ├── registration-storage.ts # Shared `ro-registration` localStorage record (docs/registration-forms.md)
 │   └── *.ts                  # Utility functions
 │
 ├── types/                    # TypeScript type definitions
@@ -66,6 +68,7 @@ randonneurs-ontario/
 │   └── navigation.json       # Site navigation structure
 │
 ├── hooks/                    # React custom hooks
+│   └── use-registration-form.ts  # Shared registration form state (docs/registration-forms.md)
 ├── public/                   # Static assets (images)
 └── docs/                     # Project documentation
 ```

--- a/docs/registration-forms.md
+++ b/docs/registration-forms.md
@@ -1,0 +1,36 @@
+# Registration Form Building Blocks
+
+The three registration forms (scheduled events, fleche, permanents) share their
+rider-details plumbing. When touching registration UI, change the shared pieces —
+don't re-inline them (see GitHub issue #82 for the duplication this replaced).
+
+## Modules
+
+| Module                                             | Owns                                                                                                                                                                                           |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `lib/registration-storage.ts`                      | The `ro-registration` localStorage record (`SavedRegistrationData`). Also read by `control-card-form.tsx` and `my-rides-section.tsx`.                                                          |
+| `hooks/use-registration-form.ts`                   | Rider-field state, load/persist of saved data, error/success/membership/match-dialog state, a11y focus+scroll effects, `handleRegistrationResult()` branching, optional upcoming-events fetch. |
+| `components/registration/registration-fields.tsx`  | `RegistrationError`, `RiderInfoFields` (name/email/phone/gender), `EmergencyContactFields`, `ShareRegistrationCheckbox`, `NotesField`. All take the hook's return value as `form`.             |
+| `components/registration/registration-success.tsx` | `RegistrationSuccess` (green checkmark), `UpcomingEventsLoading`, `UpcomingEventsSection`, `UpcomingEventCard`. Also used by `result-submission-form.tsx`.                                     |
+| `components/registration/registration-dialogs.tsx` | `RegistrationDialogs` — rider-match dialog + membership error modal.                                                                                                                           |
+
+## How a form is assembled
+
+Each form keeps only its unique sections (fleche team picker, permanent
+route/date/direction section) and its own submit handler:
+
+1. `const form = useRegistrationForm({ upcomingEventsEventId })` — pass an event
+   id to fetch "More Upcoming Events" after success; omit for permanents.
+2. The submit handler calls the right server action with `...form.riderPayload`
+   plus form-specific fields, inside `form.startTransition`.
+3. Pass the result to `form.handleRegistrationResult(result, { onNeedsMatch })`.
+   `onNeedsMatch` stashes context needed by the follow-up
+   `completeRegistrationWithRider` call (pending notes / pending event id).
+4. Render `<RegistrationDialogs form={form} onSelectRider={handleRiderSelection} />`
+   after the form.
+
+## Testing
+
+- `tests/unit/lib/registration-storage.test.ts` and
+  `tests/unit/hooks/use-registration-form.test.ts` cover the shared modules.
+- The per-form test files exercise the shared components through each form.

--- a/hooks/use-registration-form.ts
+++ b/hooks/use-registration-form.ts
@@ -1,0 +1,195 @@
+'use client'
+
+import { useState, useEffect, useRef, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { getSavedRegistrationData, saveRegistrationData } from '@/lib/registration-storage'
+import type { RegistrationResult } from '@/lib/actions/register'
+import type { RiderMatchCandidate } from '@/lib/actions/rider-match'
+import { getUpcomingEventsByEventId, type UpcomingEvent } from '@/lib/actions/rider-results'
+
+export type MembershipErrorVariant = 'no-membership' | 'trial-used'
+
+export interface UseRegistrationFormOptions {
+  /** When set, fetch up to 3 upcoming events for this event after a successful registration. */
+  upcomingEventsEventId?: string
+}
+
+/**
+ * Shared state, persistence, and result-branching for the registration forms
+ * (scheduled events, fleche, permanents). Each form keeps its own submit
+ * handler — it calls the right server action with `riderPayload` plus its
+ * unique fields, then hands the result to `handleRegistrationResult`.
+ */
+export function useRegistrationForm(options: UseRegistrationFormOptions = {}) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+
+  // Rider fields
+  const [firstName, setFirstName] = useState('')
+  const [lastName, setLastName] = useState('')
+  const [email, setEmail] = useState('')
+  const [blurredEmail, setBlurredEmail] = useState('')
+  const [phone, setPhone] = useState('')
+  const [shareRegistration, setShareRegistration] = useState(true)
+  const [gender, setGender] = useState<string>('')
+  const [emergencyContactName, setEmergencyContactName] = useState('')
+  const [emergencyContactPhone, setEmergencyContactPhone] = useState('')
+  const [homepageUrl, setHomepageUrl] = useState('')
+
+  // UI state
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+  const [membershipErrorVariant, setMembershipErrorVariant] =
+    useState<MembershipErrorVariant | null>(null)
+
+  // Fuzzy matching state
+  const [matchDialogOpen, setMatchDialogOpen] = useState(false)
+  const [matchCandidates, setMatchCandidates] = useState<RiderMatchCandidate[]>([])
+
+  // Upcoming events state
+  const [upcomingEvents, setUpcomingEvents] = useState<UpcomingEvent[]>([])
+  const [loadingEvents, setLoadingEvents] = useState(false)
+
+  const errorRef = useRef<HTMLDivElement>(null)
+  const successRef = useRef<HTMLDivElement>(null)
+
+  // Load saved data on mount
+  useEffect(() => {
+    const saved = getSavedRegistrationData()
+    if (saved) {
+      setFirstName(saved.firstName)
+      setLastName(saved.lastName)
+      setEmail(saved.email)
+      setPhone(saved.phone || '')
+      setGender(saved.gender)
+      setShareRegistration(saved.shareRegistration)
+      setEmergencyContactName(saved.emergencyContactName || '')
+      setEmergencyContactPhone(saved.emergencyContactPhone || '')
+    }
+  }, [])
+
+  // Scroll error into view when it appears
+  useEffect(() => {
+    if (error && errorRef.current) {
+      errorRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+    }
+  }, [error])
+
+  // Move focus to success message when registration completes
+  useEffect(() => {
+    if (success && successRef.current) {
+      successRef.current.focus()
+    }
+  }, [success])
+
+  /** Rider fields shaped for the register server actions. */
+  const riderPayload = {
+    firstName,
+    lastName,
+    email,
+    phone,
+    gender: gender || undefined,
+    shareRegistration,
+    emergencyContactName,
+    emergencyContactPhone,
+    homepageUrl,
+  }
+
+  /**
+   * Branch on a register-action result. `onNeedsMatch` fires just before the
+   * rider-match dialog opens so the form can stash pending context (notes,
+   * pending event id) for the follow-up `completeRegistrationWithRider` call.
+   */
+  function handleRegistrationResult(
+    result: RegistrationResult,
+    { onNeedsMatch }: { onNeedsMatch?: (result: RegistrationResult) => void } = {}
+  ) {
+    if (result.success) {
+      // Save form data to localStorage for next registration
+      saveRegistrationData({
+        firstName,
+        lastName,
+        email,
+        phone,
+        gender,
+        shareRegistration,
+        emergencyContactName,
+        emergencyContactPhone,
+      })
+      setMatchDialogOpen(false)
+      setSuccess(true)
+      router.refresh()
+
+      if (options.upcomingEventsEventId) {
+        setLoadingEvents(true)
+        getUpcomingEventsByEventId(options.upcomingEventsEventId, 3)
+          .then((eventsResult) => {
+            if (eventsResult.success && eventsResult.data) {
+              setUpcomingEvents(eventsResult.data)
+            }
+          })
+          .catch(() => {
+            // Silently fail - the events are a nice-to-have
+          })
+          .finally(() => {
+            setLoadingEvents(false)
+          })
+      }
+    } else if (result.needsRiderMatch && result.matchCandidates) {
+      onNeedsMatch?.(result)
+      setMatchCandidates(result.matchCandidates)
+      setMatchDialogOpen(true)
+    } else if (result.membershipError) {
+      setMatchDialogOpen(false)
+      setMembershipErrorVariant(result.membershipError)
+    } else {
+      setMatchDialogOpen(false)
+      setError(result.error || 'Registration failed')
+    }
+  }
+
+  return {
+    // transition
+    isPending,
+    startTransition,
+    // rider fields
+    firstName,
+    setFirstName,
+    lastName,
+    setLastName,
+    email,
+    setEmail,
+    blurredEmail,
+    setBlurredEmail,
+    phone,
+    setPhone,
+    gender,
+    setGender,
+    shareRegistration,
+    setShareRegistration,
+    emergencyContactName,
+    setEmergencyContactName,
+    emergencyContactPhone,
+    setEmergencyContactPhone,
+    homepageUrl,
+    setHomepageUrl,
+    // ui state
+    error,
+    setError,
+    success,
+    membershipErrorVariant,
+    setMembershipErrorVariant,
+    matchDialogOpen,
+    setMatchDialogOpen,
+    matchCandidates,
+    upcomingEvents,
+    loadingEvents,
+    errorRef,
+    successRef,
+    // helpers
+    riderPayload,
+    handleRegistrationResult,
+  }
+}
+
+export type RegistrationFormState = ReturnType<typeof useRegistrationForm>

--- a/lib/registration-storage.ts
+++ b/lib/registration-storage.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared localStorage persistence for rider registration details.
+ *
+ * Registration forms save the rider's info after a successful registration so
+ * the next form can pre-fill it. Other components (control card generator,
+ * "Your Upcoming Rides") read the same record.
+ */
+export const REGISTRATION_STORAGE_KEY = 'ro-registration'
+
+export interface SavedRegistrationData {
+  firstName: string
+  lastName: string
+  email: string
+  phone: string
+  gender: string
+  shareRegistration: boolean
+  emergencyContactName: string
+  emergencyContactPhone: string
+}
+
+export function getSavedRegistrationData(): SavedRegistrationData | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const saved = localStorage.getItem(REGISTRATION_STORAGE_KEY)
+    return saved ? JSON.parse(saved) : null
+  } catch {
+    return null
+  }
+}
+
+export function saveRegistrationData(data: SavedRegistrationData): void {
+  try {
+    localStorage.setItem(REGISTRATION_STORAGE_KEY, JSON.stringify(data))
+  } catch {
+    // Ignore storage errors
+  }
+}

--- a/tests/unit/hooks/use-registration-form.test.ts
+++ b/tests/unit/hooks/use-registration-form.test.ts
@@ -1,0 +1,139 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useRegistrationForm } from '@/hooks/use-registration-form'
+
+const mockRefresh = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: mockRefresh, push: vi.fn() }),
+}))
+
+const mockGetUpcomingEvents = vi.fn()
+vi.mock('@/lib/actions/rider-results', () => ({
+  getUpcomingEventsByEventId: (...args: unknown[]) => mockGetUpcomingEvents(...args),
+}))
+
+describe('useRegistrationForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    mockGetUpcomingEvents.mockResolvedValue({ success: true, data: [] })
+  })
+
+  it('loads saved registration data on mount', () => {
+    localStorage.setItem(
+      'ro-registration',
+      JSON.stringify({
+        firstName: 'Anna',
+        lastName: 'Smith',
+        email: 'anna@example.com',
+        phone: '555-1234',
+        gender: 'F',
+        shareRegistration: false,
+        emergencyContactName: 'Bob',
+        emergencyContactPhone: '555-9876',
+      })
+    )
+
+    const { result } = renderHook(() => useRegistrationForm())
+
+    expect(result.current.firstName).toBe('Anna')
+    expect(result.current.email).toBe('anna@example.com')
+    expect(result.current.gender).toBe('F')
+    expect(result.current.shareRegistration).toBe(false)
+  })
+
+  it('persists rider data, flips success, and refreshes the router on success', () => {
+    const { result } = renderHook(() => useRegistrationForm())
+
+    act(() => result.current.setFirstName('Anna'))
+    act(() => result.current.setLastName('Smith'))
+    act(() => result.current.setEmail('anna@example.com'))
+    act(() => result.current.handleRegistrationResult({ success: true }))
+
+    expect(result.current.success).toBe(true)
+    expect(mockRefresh).toHaveBeenCalled()
+    const saved = JSON.parse(localStorage.getItem('ro-registration') || '{}')
+    expect(saved.firstName).toBe('Anna')
+    expect(saved.email).toBe('anna@example.com')
+  })
+
+  it('opens the match dialog and reports pending context on needsRiderMatch', () => {
+    const onNeedsMatch = vi.fn()
+    const { result } = renderHook(() => useRegistrationForm())
+    const matchResult = {
+      success: false,
+      needsRiderMatch: true,
+      matchCandidates: [{ id: 'r1' } as never],
+    }
+
+    act(() => result.current.handleRegistrationResult(matchResult, { onNeedsMatch }))
+
+    expect(result.current.matchDialogOpen).toBe(true)
+    expect(result.current.matchCandidates).toHaveLength(1)
+    expect(onNeedsMatch).toHaveBeenCalledWith(matchResult)
+    expect(result.current.success).toBe(false)
+  })
+
+  it('surfaces membership errors and closes the dialog', () => {
+    const { result } = renderHook(() => useRegistrationForm())
+
+    act(() =>
+      result.current.handleRegistrationResult({ success: false, membershipError: 'trial-used' })
+    )
+
+    expect(result.current.membershipErrorVariant).toBe('trial-used')
+    expect(result.current.matchDialogOpen).toBe(false)
+  })
+
+  it('falls back to the error banner', () => {
+    const { result } = renderHook(() => useRegistrationForm())
+
+    act(() => result.current.handleRegistrationResult({ success: false, error: 'Nope' }))
+
+    expect(result.current.error).toBe('Nope')
+    expect(result.current.success).toBe(false)
+  })
+
+  it('uses a default error message when the action returns none', () => {
+    const { result } = renderHook(() => useRegistrationForm())
+
+    act(() => result.current.handleRegistrationResult({ success: false }))
+
+    expect(result.current.error).toBe('Registration failed')
+  })
+
+  it('fetches upcoming events after success when configured', async () => {
+    mockGetUpcomingEvents.mockResolvedValue({
+      success: true,
+      data: [
+        {
+          id: 'e1',
+          name: 'Sample Brevet',
+          date: '2099-01-01',
+          distance: 200,
+          slug: 'sample-brevet',
+          startLocation: null,
+        },
+      ],
+    })
+    const { result } = renderHook(() => useRegistrationForm({ upcomingEventsEventId: 'event-1' }))
+
+    act(() => result.current.handleRegistrationResult({ success: true }))
+
+    await waitFor(() => expect(result.current.upcomingEvents).toHaveLength(1))
+    expect(mockGetUpcomingEvents).toHaveBeenCalledWith('event-1', 3)
+    expect(result.current.loadingEvents).toBe(false)
+  })
+
+  it('does not fetch upcoming events when no event id is configured', () => {
+    const { result } = renderHook(() => useRegistrationForm())
+
+    act(() => result.current.handleRegistrationResult({ success: true }))
+
+    expect(mockGetUpcomingEvents).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/lib/registration-storage.test.ts
+++ b/tests/unit/lib/registration-storage.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  REGISTRATION_STORAGE_KEY,
+  getSavedRegistrationData,
+  saveRegistrationData,
+  type SavedRegistrationData,
+} from '@/lib/registration-storage'
+
+const sample: SavedRegistrationData = {
+  firstName: 'Anna',
+  lastName: 'Smith',
+  email: 'anna@example.com',
+  phone: '555-1234',
+  gender: 'F',
+  shareRegistration: true,
+  emergencyContactName: 'Bob Smith',
+  emergencyContactPhone: '555-9876',
+}
+
+describe('registration-storage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('uses the legacy ro-registration key so existing rider data survives', () => {
+    expect(REGISTRATION_STORAGE_KEY).toBe('ro-registration')
+  })
+
+  it('round-trips saved registration data', () => {
+    saveRegistrationData(sample)
+    expect(getSavedRegistrationData()).toEqual(sample)
+  })
+
+  it('returns null when nothing is saved', () => {
+    expect(getSavedRegistrationData()).toBeNull()
+  })
+
+  it('returns null for corrupted JSON', () => {
+    localStorage.setItem(REGISTRATION_STORAGE_KEY, '{not-json')
+    expect(getSavedRegistrationData()).toBeNull()
+  })
+
+  it('swallows storage write errors', () => {
+    vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError')
+    })
+    expect(() => saveRegistrationData(sample)).not.toThrow()
+  })
+})


### PR DESCRIPTION
Fixes #82

Removes the ~600+ duplicated lines shared by the three registration forms (and partly `control-card-form.tsx`, `my-rides-section.tsx`, `result-submission-form.tsx`) into shared modules, with zero intended behavior change:

- **`lib/registration-storage.ts`** — single owner of the `ro-registration` localStorage record (was copy-pasted in 5 files)
- **`hooks/use-registration-form.ts`** — rider-field state, saved-data load/persist, a11y focus/scroll effects, and the `success / needsRiderMatch / membershipError / error` result branching
- **`components/registration/`** — `RiderInfoFields`, `EmergencyContactFields`, `ShareRegistrationCheckbox`, `NotesField`, `RegistrationError`, `RegistrationSuccess`, `UpcomingEventsSection` + single `UpcomingEventCard` (was defined 3×), `RegistrationDialogs`

Net **−1,500/+1,032** lines. The four pre-existing form test files pass **unchanged** (1,502 unit + 170 real-DB tests green; lint/typecheck clean). New unit tests cover the storage lib and hook. Docs added in `docs/registration-forms.md`.

### Intentional standardizations (approved in plan)

1. Emergency contact uses the fleche form's `<fieldset>/<legend>` markup everywhere (better a11y; already shipping on fleche)
2. Success checkmark SVG gets `aria-hidden`; success `<h2>` gets `tracking-tight` everywhere (permanent form gains it)
3. `UpcomingEventCard` link keeps fleche's `aria-label`; loading spinner keeps `role="status"`
4. Fleche form now also fetches upcoming events after a rider-match-dialog success (previously direct-submit only)
5. Permanent form opens the rider-match dialog even if `pendingData` is somehow absent (theoretical path; previously fell through to generic error)

Result-submission success screen additionally gains `role="status"` + the shared `data-testid` — a11y-positive, no co-rendered duplicate.

Screenshots reviewed for the permanent, scheduled-event, control-card, and homepage views (only expected fieldset delta). Fleche page skipped — no seeded fleche event locally; result-submission success is token-gated (unit-covered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)